### PR TITLE
add extra sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,32 +17,45 @@ If you like this component, please give it a star on [github](https://github.com
 ## Installation
 
 1. Ensure that [HACS](https://hacs.xyz) is installed.
-2. Install **EPEX Spot** integration via HACS.
+2. Install **EPEX Spot** integration via HACS:
+
+   [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=mampfes&repository=ha_epex_spot)
+
 3. Add **EPEX Spot** integration to Home Assistant:
 
-   [![badge](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start?domain=epex_spot)
+   [![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start?domain=epex_spot)
 
 In case you would like to install manually:
 
 1. Copy the folder `custom_components/epex_spot` to `custom_components` in your Home Assistant `config` folder.
 2. Add **EPEX Spot** integration to Home Assistant:
 
-    [![badge](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start?domain=epex_spot)
+    [![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start?domain=epex_spot)
 
 ## Sensors
 
-This component provides one sensor for market prices. The sensor state is the current price in EUR/MWh.
+This integration provides the following sensors:
 
-Some sources (like EPEX Spot Web Scraper) provide additional sensors like buy volume, sell volume or volume.
+1. Current market price
+2. Average market price during the day
+3. Lowest market price during the day
+4. Highest market price during the day
+5. Current market price quantile during the day
+6. Rank of the current market price during the day
 
-### Sensor Attributes
+The *EPEX Spot Web Scraper* provides some additional sensors:
 
-In addition to the current market price, the price sensor also provides a list of upcoming prices per hour:
+- Buy Volume
+- Sell Volume
+- Volume
+
+### 1. Current Market Price Sensor
+
+The sensor value reports the current market price which will be updated every hour.
+
+The sensor attributes contains a list of all available market prices (today and tomorrow if available):
 
 ```yaml
-unit_of_measurement: EUR/MWh
-icon: mdi:currency-eur
-friendly_name: EPEX Spot DE-LU Price
 data:
   - start_time: '2022-12-15T23:00:00+00:00'
     end_time: '2022-12-16T00:00:00+00:00'
@@ -54,6 +67,52 @@ data:
     end_time: '2022-12-16T02:00:00+00:00'
     price_eur_per_mwh: 280.19
 ```
+
+### 2. Average Market Price Sensor
+
+The sensor value reports the average market price during the day.
+
+### 3. Lowest Market Price Sensor
+
+The sensor value reports the lowest market price during the day.
+
+The sensor attributes contains the start and endtime of the lowest market price timeframe.
+
+```yaml
+start_time: '2023-02-15T22:00:00+00:00'
+end_time: '2023-02-15T23:00:00+00:00'
+```
+
+### 4. Highest Market Price Sensor
+
+The sensor value reports the highest market price during the day.
+
+The sensor attributes contains the start and endtime of the highest market price timeframe.
+
+```yaml
+start_time: '2023-02-15T22:00:00+00:00'
+end_time: '2023-02-15T23:00:00+00:00'
+```
+
+### 5. Quantile Sensor
+
+The sensor value reports the quantile between the lowest market price and the highest market price during the day in the range between 0 .. 1.
+
+Examples:
+
+- The sensor reports 0 if the current market price is the lowest during the day.
+- The sensor reports 1 if the current market price is the highest during the day.
+- If the sensor reports e.g., 0.25, then the current market price is 25% of the range between the lowest and the highest market price.
+
+### 6. Rank Sensor
+
+The sensor value reports the rank of the current market price during the day. Or in other words: The number of hours in which the price is lower than the current price.
+
+Examples:
+
+- The sensor reports 0 if the current market price is the lowest during the day. There is no lower market price during the day.
+- The sensor reports 23 if the current market price is the highest during the day (if the market price will be updated hourly). There are 23 hours which are cheaper than the current hour market price.
+- The sensor reports 1 if the current market price is the 2nd cheapest during the day. There is 1 one which is cheaper than the current hour market price.
 
 ## FAQ
 

--- a/custom_components/epex_spot/EPEXSpot/Awattar/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/Awattar/__init__.py
@@ -49,7 +49,7 @@ class Awattar:
     def __init__(self, market_area):
         self._market_area = market_area
         self._url = self.URL.format(market_area=market_area)
-        self._marketprices = []
+        self._marketdata = []
 
     @property
     def name(self):
@@ -60,12 +60,12 @@ class Awattar:
         return self._market_area
 
     @property
-    def marketprices(self):
-        return self._marketprices
+    def marketdata(self):
+        return self._marketdata
 
     def fetch(self):
         data = self._fetch_data(self._url)
-        self._marketprices = self._extract_marketprices(data["data"])
+        self._marketdata = self._extract_marketdata(data["data"])
 
     def _fetch_data(self, url):
         start = dt.now().replace(
@@ -76,7 +76,7 @@ class Awattar:
         r.raise_for_status()
         return r.json()
 
-    def _extract_marketprices(self, data):
+    def _extract_marketdata(self, data):
         entries = []
         for entry in data:
             entries.append(Marketprice(entry))

--- a/custom_components/epex_spot/EPEXSpot/EPEXSpotWeb/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/EPEXSpotWeb/__init__.py
@@ -92,7 +92,7 @@ class EPEXSpotWeb:
     def __init__(self, market_area):
         self._market_area = market_area
         self._duration = timedelta(minutes=60)
-        self._marketprices = []
+        self._marketdata = []
 
     @property
     def name(self):
@@ -103,14 +103,14 @@ class EPEXSpotWeb:
         return self._market_area
 
     @property
-    def marketprices(self):
-        return self._marketprices
+    def marketdata(self):
+        return self._marketdata
 
     def fetch(self):
         delivery_date = datetime.now(ZoneInfo("Europe/Berlin"))
         # get data for remaining day and upcoming day
         # Data for the upcoming day is typically available at 12:45
-        self._marketprices = self._fetch_day(delivery_date) + self._fetch_day(
+        self._marketdata = self._fetch_day(delivery_date) + self._fetch_day(
             delivery_date + timedelta(days=1)
         )
 
@@ -205,14 +205,14 @@ class EPEXSpotWeb:
         # convert timezone to UTC (and adjust timestamp)
         start_time = start_time.astimezone(timezone.utc)
 
-        marketprices = []
+        marketdata = []
         for row in rows:
             end_time = start_time + self._duration
             buy_volume_col = row.td
             sell_volume_col = buy_volume_col.find_next_sibling("td")
             volume_col = sell_volume_col.find_next_sibling("td")
             price_col = volume_col.find_next_sibling("td")
-            marketprices.append(
+            marketdata.append(
                 Marketprice(
                     start_time=start_time,
                     end_time=end_time,
@@ -224,4 +224,4 @@ class EPEXSpotWeb:
             )
             start_time = end_time
 
-        return marketprices
+        return marketdata

--- a/custom_components/epex_spot/__init__.py
+++ b/custom_components/epex_spot/__init__.py
@@ -4,10 +4,12 @@ from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.event import async_track_time_interval, async_track_time_change
+from homeassistant.helpers.dispatcher import dispatcher_send
+from homeassistant.util import dt
 
 from .const import (CONF_MARKET_AREA, CONF_SOURCE, CONF_SOURCE_AWATTAR,
-                    CONF_SOURCE_EPEX_SPOT_WEB, DOMAIN)
+                    CONF_SOURCE_EPEX_SPOT_WEB, DOMAIN, UPDATE_SENSORS_SIGNAL)
 from .EPEXSpot import Awattar, EPEXSpotWeb
 
 _LOGGER = logging.getLogger(__name__)
@@ -43,6 +45,61 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
     return unload_ok
 
+class SourceDecorator:
+    def __init__(self, unique_id, source):
+        self._source = source
+        self._unique_id = unique_id
+        self._marketdata_now = None
+        self._sorted_marketdata_today = []
+        self._cheapest_sorted_marketdata_today = None
+        self._most_expensive_sorted_marketdata_today = None
+
+    @property
+    def unique_id(self):
+        return self._unique_id
+
+    @property
+    def name(self):
+        return self._source.name
+
+    @property
+    def marketdata(self):
+        return self._source.marketdata
+
+    @property
+    def market_area(self):
+        return self._source.market_area
+
+    @property
+    def marketdata_now(self):
+        return self._marketdata_now
+
+    @property
+    def sorted_marketdata_today(self):
+        return self._sorted_marketdata_today
+
+    def fetch(self):
+        self._source.fetch()
+
+    def update_time(self):
+        if (len(self.marketdata)) == 0:
+            self._marketdata_now = None
+            self._sorted_marketdata_today = []
+            return
+
+        now = dt.now()
+
+        # find current entry in marketdata list
+        self._marketdata_now = next(filter(lambda e: e.start_time <= now and e.end_time > now, self.marketdata))
+
+        # get list of entries for today
+        start_of_day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        end_of_day = start_of_day + timedelta(days=1)
+
+        sorted_marketdata_today = filter(lambda e: e.start_time >= start_of_day and e.end_time <= end_of_day, self.marketdata)
+        sorted_sorted_marketdata_today = sorted(sorted_marketdata_today, key=lambda e: e.price_eur_per_mwh)
+        self._sorted_marketdata_today = sorted_sorted_marketdata_today
+
 
 class EpexSpotShell:
     """Shell object for EPEX Spot. Stored in hass.data."""
@@ -51,19 +108,18 @@ class EpexSpotShell:
         """Initialize the instance."""
         self._hass = hass
         self._sources = {}
+        self._timer_listener_hour_change = None
+        self._timer_listener_fetch = None
+
+    def is_idle(self) -> bool:
+        return not bool(self._sources)
 
     def get_source(self, unique_id):
         return self._sources[unique_id]
 
     def add_entry(self, config_entry: ConfigEntry):
         """Add entry."""
-        if self.is_idle():
-            # This is the first entry, therefore start the timer
-            self._fetch_callback_listener = async_track_time_interval(
-                self._hass, self._fetch_callback, timedelta(hours=1)
-            )
-
-            # async_track_time_change(hass, action, hour=None, minute=None, second=None):
+        is_idle = self.is_idle()
 
         if config_entry.data[CONF_SOURCE] == CONF_SOURCE_AWATTAR:
             source = Awattar.Awattar(market_area=config_entry.data[CONF_MARKET_AREA])
@@ -72,30 +128,53 @@ class EpexSpotShell:
                 market_area=config_entry.data[CONF_MARKET_AREA]
             )
 
-        self._hass.add_job(source.fetch)
-
+        source = SourceDecorator(config_entry.unique_id, source)
         self._sources[config_entry.unique_id] = source
+
+        self._hass.add_job(lambda: self._fetch_source_and_dispatch(source))
+
+        source.update_time()
+
+        if is_idle:
+            # This is the first entry, therefore start the timers
+            self._timer_listener_hour_change = async_track_time_change(self._hass, self._on_hour_change, hour=None, minute=0, second=0)
+            self._timer_listener_fetch = async_track_time_change(self._hass, self._on_fetch_sources, hour=None, minute=58, second=0)
 
     def remove_entry(self, config_entry: ConfigEntry):
         """Remove entry."""
         self._sources.pop(config_entry.unique_id)
 
         if self.is_idle():
-            # This was the last source, therefore stop the timer
-            remove_listener = self._fetch_callback_listener
+            # This was the last source, therefore stop the timers
+            remove_listener = self._timer_listener_hour_change
             if remove_listener is not None:
                 remove_listener()
 
-    def is_idle(self) -> bool:
-        return not bool(self._sources)
+            remove_listener = self._timer_listener_fetch
+            if remove_listener is not None:
+                remove_listener()
+
+    def _fetch_source_and_dispatch(self, source):
+        self._fetch_source(source)
+        source.update_time()
+        dispatcher_send(self._hass, UPDATE_SENSORS_SIGNAL)
+
+    def _fetch_source(self, source):
+        try:
+            source.fetch()
+        except Exception as error:
+            _LOGGER.error(f"fetch failed : {error}")
 
     @callback
-    def _fetch_callback(self, *_):
-        self._hass.add_job(self._fetch)
+    def _on_fetch_sources(self, *_):
+        for source in self._sources.values():
+           self._hass.add_job(lambda: self._fetch_source(source))
 
-    def _fetch(self, *_):
-        for source in self._sources:
-            try:
-                self.get_source(source).fetch()
-            except Exception as error:
-                _LOGGER.error(f"fetch failed : {error}")
+    @callback
+    def _on_hour_change(self, *_):
+        # adjust marketdata in all sources to current hour
+        for source in self._sources.values():
+            source.update_time()
+
+        # update all sensors immediately
+        dispatcher_send(self._hass, UPDATE_SENSORS_SIGNAL)

--- a/custom_components/epex_spot/const.py
+++ b/custom_components/epex_spot/const.py
@@ -9,3 +9,5 @@ CONF_MARKET_AREA = "market_area"
 # possible values for CONF_SOURCE
 CONF_SOURCE_AWATTAR = "Awattar"
 CONF_SOURCE_EPEX_SPOT_WEB = "EPEX Spot Web Scraper"
+
+UPDATE_SENSORS_SIGNAL = f"{DOMAIN}_update_sensors_signal"

--- a/custom_components/epex_spot/manifest.json
+++ b/custom_components/epex_spot/manifest.json
@@ -4,9 +4,9 @@
   "config_flow": true,
   "requirements": ["bs4"],
   "dependencies": [],
-  "documentation": "https://github.com/mampfes/hacs_epex_spot",
-  "issue_tracker": "https://github.com/mampfes/hacs_epex_spot/issues",
+  "documentation": "https://github.com/mampfes/ha_epex_spot",
+  "issue_tracker": "https://github.com/mampfes/ha_epex_spot/issues",
   "codeowners": ["@mampfes"],
   "iot_class": "cloud_polling",
-  "version": "1.0.1"
+  "version": "1.2.0"
 }

--- a/custom_components/epex_spot/test_awattar.py
+++ b/custom_components/epex_spot/test_awattar.py
@@ -6,6 +6,6 @@ service = Awattar.Awattar(market_area="de")
 print(service.MARKET_AREAS)
 
 service.fetch()
-print(f"count = {len(service.marketprices)}")
-for e in service.marketprices:
+print(f"count = {len(service.marketdata)}")
+for e in service.marketdata:
     print(f"{e.start_time}: {e.price_eur_per_mwh} {e.UOM_EUR_PER_MWh}")

--- a/custom_components/epex_spot/test_epex_spot_web.py
+++ b/custom_components/epex_spot/test_epex_spot_web.py
@@ -6,6 +6,6 @@ service = EPEXSpot.EPEXSpotWeb.EPEXSpotWeb(market_area="DE-LU")
 print(service.MARKET_AREAS)
 
 service.fetch()
-print(f"count = {len(service.marketprices)}")
-for e in service.marketprices:
+print(f"count = {len(service.marketdata)}")
+for e in service.marketdata:
     print(f"{e.start_time}: {e.price_eur_per_mwh} {e.UOM_EUR_PER_MWh}")


### PR DESCRIPTION
This commit provides additional sensors for:

- minimum price during the day
- maximum price during the day
- average price during the day
- rank during the day
- quantile during the day

This commit improves the update point in time of all sensors: They are now really close (typically < 1sec) to the hour. Before, the update was triggered by 30sec default Home Assistant polling.

This commit also adds price in ct/kWh for all relevant sensors as extra attribute.

fix #14 