### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,8 +490,6 @@ experimental:
   color_threshold: true
 yaxis:
   - id: uurprijs
-    min: 0.1
-    max: 0.5
     decimals: 2
     apex_config:
       title:


### PR DESCRIPTION
Fix line generation, with these min and max values in place - the price graph wouldn't show a line. Maybe this is still a leftover from when pricing was in €c ?