### PR TITLE
(temporary) disable SSL check for epexspot.com

### DIFF
--- a/custom_components/epex_spot/EPEXSpot/EPEXSpotWeb/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/EPEXSpotWeb/__init__.py
@@ -184,7 +184,9 @@ class EPEXSpotWeb:
             #          "ajax_page_state[libraries]": "bootstrap/popover,bootstrap/tooltip,core/html5shiv,core/jquery.form,epex/global-scripts,epex/global-styling,epex/highcharts,epex_core/data-disclaimer,epex_market_data/filters,epex_market_data/tables,eu_cookie_compliance/eu_cookie_compliance_default,statistics/drupal.statistics,system/base",  # noqa: E501
         }
 
-        async with self._session.post(self.URL, params=params, data=data) as resp:
+        async with self._session.post(
+            self.URL, params=params, data=data, verify_ssl=False
+        ) as resp:
             resp.raise_for_status()
             return await resp.json()
 

--- a/custom_components/epex_spot/manifest.json
+++ b/custom_components/epex_spot/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/mampfes/ha_epex_spot/issues",
   "requirements": ["bs4"],
-  "version": "2.3.0"
+  "version": "2.3.1"
 }


### PR DESCRIPTION
https://www.epexspot.com renewed their SSL certificate with GlobalSign for a year.

This certificate is not trusted in all browsers and needs a root certificate to be installed.

This is a workaround.

fix #89