### PR TITLE
fix: float representation

### DIFF
--- a/custom_components/epex_spot/EPEXSpot/Awattar/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/Awattar/__init__.py
@@ -38,7 +38,7 @@ class Marketprice:
 
     @property
     def price_ct_per_kwh(self):
-        return self._price_eur_per_mwh / 10
+        return round(self._price_eur_per_mwh / 10, 3)
 
 
 def toEpochMilliSec(dt: datetime) -> int:

--- a/custom_components/epex_spot/EPEXSpot/EPEXSpotWeb/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/EPEXSpotWeb/__init__.py
@@ -50,7 +50,7 @@ class Marketprice:
 
     @property
     def price_ct_per_kwh(self):
-        return self._price_eur_per_mwh / 10
+        return round(self._price_eur_per_mwh / 10, 3)
 
     @property
     def buy_volume_mwh(self):

--- a/custom_components/epex_spot/EPEXSpot/SMARD/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/SMARD/__init__.py
@@ -54,7 +54,7 @@ class Marketprice:
 
     @property
     def price_ct_per_kwh(self):
-        return self._price_eur_per_mwh / 10
+        return round(self._price_eur_per_mwh / 10, 3)
 
 
 class SMARD:

--- a/custom_components/epex_spot/EPEXSpot/smartENERGY/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/smartENERGY/__init__.py
@@ -28,7 +28,7 @@ class Marketprice:
 
     @property
     def price_eur_per_mwh(self):
-        return self._price_ct_per_kwh * 10
+        return round(self._price_ct_per_kwh * 10, 2)
 
     @property
     def price_ct_per_kwh(self):

--- a/custom_components/epex_spot/SourceShell.py
+++ b/custom_components/epex_spot/SourceShell.py
@@ -141,7 +141,7 @@ class SourceShell:
         net_p += surcharge_abs
         net_p *= 1 + (tax / 100)
 
-        return net_p
+        return round(net_p, 3)
 
     def find_extreme_price_interval(self, call_data, cmp):
         duration: timedelta = call_data[CONF_DURATION]
@@ -167,6 +167,6 @@ class SourceShell:
             "start": result["start"],
             "end": result["start"] + duration,
             "price_eur_per_mwh": result["price_per_hour"],
-            "price_ct_per_kwh": result["price_per_hour"] / 10,
+            "price_ct_per_kwh": round(result["price_per_hour"] / 10, 3),
             "net_price_ct_per_kwh": self.to_net_price(result["price_per_hour"]),
         }

--- a/custom_components/epex_spot/extreme_price_interval.py
+++ b/custom_components/epex_spot/extreme_price_interval.py
@@ -37,7 +37,7 @@ def _calc_interval_price(marketdata, start_time: datetime, duration: timedelta):
 
         start_time = mp.end_time
 
-    return total_price
+    return round(total_price, 2)
 
 
 def _calc_start_times(
@@ -91,11 +91,13 @@ def find_extreme_price_interval(marketdata, start_times, duration: timedelta, cm
     if interval_start_time is None:
         return None
 
+    interval_price = round(interval_price, 2)
+
     return {
         "start": interval_start_time,
         "end": interval_start_time + duration,
         "interval_price": interval_price,
-        "price_per_hour": interval_price * SECONDS_PER_HOUR / duration.total_seconds(),
+        "price_per_hour": round(interval_price * SECONDS_PER_HOUR / duration.total_seconds(), 2),
     }
 
 

--- a/custom_components/epex_spot/sensor.py
+++ b/custom_components/epex_spot/sensor.py
@@ -50,7 +50,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 
 def to_ct_per_kwh(price_eur_per_mwh):
-    return price_eur_per_mwh / 10
+    return round(price_eur_per_mwh / 10, 3)
 
 
 class EpexSpotPriceSensorEntity(EpexSpotEntity, SensorEntity):


### PR DESCRIPTION
Since floats cannot always be displayed precisely in Python, there are currently ugly fractions in the attributes.
This PR fixes the cases that I have noticed, there may be more.

EUR/MWh are rounded to 2 decimal places and ct/kWh to 3.

current:
```
- start_time: '2024-01-11T04:00:00+01:00'
end_time: '2024-01-11T04:15:00+01:00'
price_eur_per_mwh: 82.10000000000001
price_ct_per_kwh: 8.21
```
fixed:
```
- start_time: '2024-01-11T04:00:00+01:00'
  end_time: '2024-01-11T05:00:00+01:00'
  price_eur_per_mwh: 82.1
  price_ct_per_kwh: 8.21
```