### PR TITLE
refactor: define all attributes as const

### DIFF
--- a/custom_components/epex_spot/const.py
+++ b/custom_components/epex_spot/const.py
@@ -3,6 +3,19 @@
 # Component domain, used to store component data in hass data.
 DOMAIN = "epex_spot"
 
+ATTR_DATA = "data"
+ATTR_START_TIME = "start_time"
+ATTR_END_TIME = "end_time"
+ATTR_BUY_VOLUME_MWH = "buy_volume_mwh"
+ATTR_SELL_VOLUME_MWH = "sell_volume_mwh"
+ATTR_VOLUME_MWH = "volume_mwh"
+ATTR_RANK = "rank"
+ATTR_QUANTILE = "quantile"
+ATTR_PRICE_EUR_PER_MWH = "price_eur_per_mwh"
+ATTR_PRICE_CT_PER_KWH = "price_ct_per_kwh"
+ATTR_PRICE_GBP_PER_MWH = "price_gbp_per_mwh"
+ATTR_PRICE_PENCE_PER_KWH = "price_pence_per_kwh"
+
 CONF_SOURCE = "source"
 CONF_MARKET_AREA = "market_area"
 

--- a/custom_components/epex_spot/localization.py
+++ b/custom_components/epex_spot/localization.py
@@ -1,5 +1,12 @@
 from dataclasses import dataclass
 
+from .const import (
+    ATTR_PRICE_CT_PER_KWH,
+    ATTR_PRICE_EUR_PER_MWH,
+    ATTR_PRICE_GBP_PER_MWH,
+    ATTR_PRICE_PENCE_PER_KWH,
+)
+
 
 @dataclass(frozen=True, slots=True)
 class Localize:
@@ -15,14 +22,14 @@ CURRENCY_MAPPING = {
         uom_per_mwh="EUR/MWh",
         uom_per_kwh="ct/kWh",
         icon="mdi:currency-eur",
-        attr_name_per_mwh="price_eur_per_mwh",
-        attr_name_per_kwh="price_ct_per_kwh",
+        attr_name_per_mwh=ATTR_PRICE_EUR_PER_MWH,
+        attr_name_per_kwh=ATTR_PRICE_CT_PER_KWH,
     ),
     "GBP": Localize(
         uom_per_mwh="GBP/MWh",
         uom_per_kwh="pence/kWh",
         icon="mdi:currency-gbp",
-        attr_name_per_mwh="price_gbp_per_mwh",
-        attr_name_per_kwh="price_pence_per_kwh",
+        attr_name_per_mwh=ATTR_PRICE_GBP_PER_MWH,
+        attr_name_per_kwh=ATTR_PRICE_PENCE_PER_KWH,
     ),
 }

--- a/custom_components/epex_spot/sensor.py
+++ b/custom_components/epex_spot/sensor.py
@@ -9,12 +9,20 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.helpers.typing import StateType
 
-from .const import CONF_SOURCE, CONF_SOURCE_EPEX_SPOT_WEB, DOMAIN
+from .const import (
+    ATTR_BUY_VOLUME_MWH,
+    ATTR_DATA,
+    ATTR_END_TIME,
+    ATTR_QUANTILE,
+    ATTR_RANK,
+    ATTR_SELL_VOLUME_MWH,
+    ATTR_START_TIME,
+    ATTR_VOLUME_MWH,
+    CONF_SOURCE,
+    CONF_SOURCE_EPEX_SPOT_WEB,
+    DOMAIN,
+)
 from . import EpexSpotEntity, EpexSpotDataUpdateCoordinator as DataUpdateCoordinator
-
-ATTR_DATA = "data"
-ATTR_START_TIME = "start_time"
-ATTR_END_TIME = "end_time"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -148,7 +156,7 @@ class EpexSpotBuyVolumeSensorEntity(EpexSpotEntity, SensorEntity):
             {
                 ATTR_START_TIME: dt_util.as_local(e.start_time).isoformat(),
                 ATTR_END_TIME: dt_util.as_local(e.end_time).isoformat(),
-                "buy_volume_mwh": e.buy_volume_mwh,
+                ATTR_BUY_VOLUME_MWH: e.buy_volume_mwh,
             }
             for e in self._source.marketdata
         ]
@@ -180,7 +188,7 @@ class EpexSpotSellVolumeSensorEntity(EpexSpotEntity, SensorEntity):
             {
                 ATTR_START_TIME: dt_util.as_local(e.start_time).isoformat(),
                 ATTR_END_TIME: dt_util.as_local(e.end_time).isoformat(),
-                "sell_volume_mwh": e.sell_volume_mwh,
+                ATTR_SELL_VOLUME_MWH: e.sell_volume_mwh,
             }
             for e in self._source.marketdata
         ]
@@ -212,7 +220,7 @@ class EpexSpotVolumeSensorEntity(EpexSpotEntity, SensorEntity):
             {
                 ATTR_START_TIME: dt_util.as_local(e.start_time).isoformat(),
                 ATTR_END_TIME: dt_util.as_local(e.end_time).isoformat(),
-                "volume_mwh": e.volume_mwh,
+                ATTR_VOLUME_MWH: e.volume_mwh,
             }
             for e in self._source.marketdata
         ]
@@ -249,7 +257,7 @@ class EpexSpotRankSensorEntity(EpexSpotEntity, SensorEntity):
             {
                 ATTR_START_TIME: dt_util.as_local(e.start_time).isoformat(),
                 ATTR_END_TIME: dt_util.as_local(e.end_time).isoformat(),
-                "rank": sorted_prices.index(e.price_eur_per_mwh),
+                ATTR_RANK: sorted_prices.index(e.price_eur_per_mwh),
             }
             for e in self._source.sorted_marketdata_today
         ]
@@ -286,7 +294,7 @@ class EpexSpotQuantileSensorEntity(EpexSpotEntity, SensorEntity):
             {
                 ATTR_START_TIME: dt_util.as_local(e.start_time).isoformat(),
                 ATTR_END_TIME: dt_util.as_local(e.end_time).isoformat(),
-                "quantile": (e.price_eur_per_mwh - min_price) / (max_price - min_price),
+                ATTR_QUANTILE: (e.price_eur_per_mwh - min_price) / (max_price - min_price),
             }
             for e in self._source.sorted_marketdata_today
         ]


### PR DESCRIPTION
A little tidying up to make all attribute names accessible as consts in one place and create the basis for the next PR (#95).