### PR TITLE
return data starting yesterday

### DIFF
--- a/custom_components/epex_spot/EPEXSpot/SMARD/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/SMARD/__init__.py
@@ -114,9 +114,18 @@ class SMARD:
                 if entry[1] is not None:
                     entries.append(Marketprice(entry))
 
-        self._marketdata = entries[
-            -72:
-        ]  # limit number of entries to protect HA recorder
+        if entries[-1].start_time.date() == datetime.today().date():
+            # latest data is on the same day, only return 48 entries
+            # thats yesterday and today
+            self._marketdata = entries[
+                -48:
+            ]  # limit number of entries to protect HA recorder           
+        else:
+            # latest data is tomorrow, return 72 entries
+            # thats yesterday, today and tomorrow
+            self._marketdata = entries[
+                -72:
+            ]  # limit number of entries to protect HA recorder
 
     async def _fetch_data(
         self, latest_timestamp, smard_filter, smard_region, smard_resolution


### PR DESCRIPTION
changed the behavior of smart.de data source to only return data starting with yesterday. 

current behavior was:
if data of tomorrow is available:
return yesterday, today and tomorrow
if data of tomorrow is not available
return the day before yesterday, yesterday and today
