### PR TITLE
rename bs4 in requirements

### DIFF
--- a/custom_components/epex_spot/manifest.json
+++ b/custom_components/epex_spot/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/mampfes/ha_epex_spot",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/mampfes/ha_epex_spot/issues",
-  "requirements": ["bs4"],
+  "requirements": ["beautifulsoup4"],
   "version": "2.3.5"
 }


### PR DESCRIPTION
While packaging this component for nixos i noticed, that you list beautifulsoup4 as "bs4". This requires a an additional step when handling the package since the required package is called "beautifulsoup4".
In another of your custom components (waste collection schedule)  you use the full name for beautifulsoup4 in requirements so maybe this is possible here as well.
If "bs4" is used here for a specific reason, just close this PR and I can handle it in the package definition. Thx