### PR TITLE
Add Tibber energy price source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 .vscode/
 .mypy_cache/
 venv/
+.venv/

--- a/custom_components/epex_spot/EPEXSpot/Tibber/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/Tibber/__init__.py
@@ -35,7 +35,9 @@ class Marketprice:
     def __init__(self, data):
         self._start_time = datetime.fromisoformat(data["startsAt"])
         self._end_time   = self._start_time + timedelta(hours = 1)
-        self._price_ct_per_kwh = round(float(data["energy"]) * 100, 3)
+        # Tibber already returns the actual net price for the customer
+        # so we can use that
+        self._price_ct_per_kwh = round(float(data["total"]) * 100, 3)
 
     def __repr__(self):
         return f"{self.__class__.__name__}(start: {self._start_time.isoformat()}, end: {self._end_time.isoformat()}, marketprice: {self._price_ct_per_kwh} {self.UOM_CT_PER_kWh})"  # noqa: E501

--- a/custom_components/epex_spot/EPEXSpot/Tibber/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/Tibber/__init__.py
@@ -1,0 +1,111 @@
+import aiohttp
+from datetime import datetime, timedelta
+import logging
+
+TIBBER_QUERY = """
+{
+  viewer {
+    homes {
+      currentSubscription{
+        priceInfo{
+          today {
+            total
+            energy
+            tax
+            startsAt
+            currency
+          }
+          tomorrow {
+            total
+            energy
+            tax
+            startsAt
+            currency
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+class Marketprice:
+    UOM_CT_PER_kWh = "ct/kWh"
+
+    def __init__(self, data):
+        self._start_time = datetime.fromisoformat(data["startsAt"])
+        self._end_time   = self._start_time + timedelta(hours = 1)
+        self._price_ct_per_kwh = round(float(data["energy"]) * 100, 3)
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(start: {self._start_time.isoformat()}, end: {self._end_time.isoformat()}, marketprice: {self._price_ct_per_kwh} {self.UOM_CT_PER_kWh})"  # noqa: E501
+
+    @property
+    def start_time(self):
+        return self._start_time
+    
+    @property
+    def end_time(self):
+        return self._end_time
+    
+    @property
+    def price_eur_per_mwh(self):
+        return round(self._price_ct_per_kwh * 10, 2)
+    
+    @property
+    def price_ct_per_kwh(self):
+        return self._price_ct_per_kwh
+
+class Tibber:
+
+    # DEMO_TOKEN = "5K4MVS-OjfWhK_4yrjOlFe1F6kJXPVf7eQYggo8ebAE"
+    #               123456789.123456789.123456789.123456789.123
+    URL = "https://api.tibber.com/v1-beta/gql"
+
+    MARKET_AREAS = ("de", "nl", "no", "se",)
+    
+    def __init__(self, market_area, session: aiohttp.ClientSession, token=None):
+        self._session = session
+        self._token = token
+        self._market_area = market_area
+        self._duration = 60
+        self._marketdata = []
+
+    @property
+    def name(self):
+        return "Tibber API v1-beta"
+    
+    @property
+    def market_area(self):
+        return self._market_area
+    
+    @property
+    def duration(self):
+        return self._duration
+    
+    @property
+    def currency(self):
+        return "EUR"
+    
+    @property
+    def marketdata(self):
+        return self._marketdata
+    
+    async def fetch(self):
+        data = await self._fetch_data(self.URL)
+        self._marketdata = self._extract_marketdata(data["data"]["viewer"]["homes"][0]["currentSubscription"]["priceInfo"])
+
+    async def _fetch_data(self, url):
+        async with self._session.post(
+            self.URL, data={ "query": TIBBER_QUERY }, headers={ "Authorization": "Bearer {}".format(self._token) }
+        ) as resp:
+            resp.raise_for_status()
+            return await resp.json()
+    
+    def _extract_marketdata(self, data):
+        entries = []
+        for entry in data["today"]:
+            entries.append(Marketprice(entry))
+        for entry in data["tomorrow"]:
+            entries.append(Marketprice(entry))
+        return entries

--- a/custom_components/epex_spot/SourceShell.py
+++ b/custom_components/epex_spot/SourceShell.py
@@ -138,20 +138,17 @@ class SourceShell:
         self._sorted_marketdata_today = sorted_sorted_marketdata_today
 
     def to_net_price(self, price_eur_per_mwh):
-        surcharge_pct = self._config_entry.options.get(
-            CONF_SURCHARGE_PERC, DEFAULT_SURCHARGE_PERC
-        )
-        surcharge_abs = self._config_entry.options.get(
-            CONF_SURCHARGE_ABS, DEFAULT_SURCHARGE_ABS
-        )
-        tax = self._config_entry.options.get(CONF_TAX, DEFAULT_TAX)
-
         net_p = price_eur_per_mwh / 10  # convert from EUR/MWh to ct/kWh
-        # Tibber adds tax to base market price and adds fixed surcharge later
-        if self.name == "Tibber API v1-beta":
-            net_p += abs(net_p) * (tax / 100) # assuming they don't charge negative taxes here
-            net_p += surcharge_abs
-        else:
+
+        # Tibber already reaturns the net price for the customer
+        if self.name != "Tibber API v1-beta":
+            surcharge_pct = self._config_entry.options.get(
+                CONF_SURCHARGE_PERC, DEFAULT_SURCHARGE_PERC
+            )
+            surcharge_abs = self._config_entry.options.get(
+                CONF_SURCHARGE_ABS, DEFAULT_SURCHARGE_ABS
+            )
+            tax = self._config_entry.options.get(CONF_TAX, DEFAULT_TAX)
             net_p = net_p + abs(net_p) * surcharge_pct / 100
             net_p += surcharge_abs
             net_p *= 1 + (tax / 100)

--- a/custom_components/epex_spot/SourceShell.py
+++ b/custom_components/epex_spot/SourceShell.py
@@ -141,7 +141,7 @@ class SourceShell:
         net_p = price_eur_per_mwh / 10  # convert from EUR/MWh to ct/kWh
 
         # Tibber already reaturns the net price for the customer
-        if self.name != "Tibber API v1-beta":
+        if "Tibber API" not in self.name:
             surcharge_pct = self._config_entry.options.get(
                 CONF_SURCHARGE_PERC, DEFAULT_SURCHARGE_PERC
             )

--- a/custom_components/epex_spot/SourceShell.py
+++ b/custom_components/epex_spot/SourceShell.py
@@ -36,10 +36,6 @@ _LOGGER = logging.getLogger(__name__)
 
 class SourceShell:
     def __init__(self, config_entry: ConfigEntry, session: aiohttp.ClientSession):
-        if (config_entry.unique_id == "epex_spot Tibber de"):
-            _LOGGER.critical(config_entry)
-            _LOGGER.critical(config_entry.data)
-
         self._config_entry = config_entry
         self._marketdata_now = None
         self._sorted_marketdata_today = []

--- a/custom_components/epex_spot/const.py
+++ b/custom_components/epex_spot/const.py
@@ -18,12 +18,14 @@ ATTR_PRICE_PENCE_PER_KWH = "price_pence_per_kwh"
 
 CONF_SOURCE = "source"
 CONF_MARKET_AREA = "market_area"
+CONF_TOKEN = "token"
 
 # possible values for CONF_SOURCE
 CONF_SOURCE_AWATTAR = "Awattar"
 CONF_SOURCE_EPEX_SPOT_WEB = "EPEX Spot Web Scraper"
 CONF_SOURCE_SMARD_DE = "SMARD.de"
 CONF_SOURCE_SMARTENERGY = "smartENERGY.at"
+CONF_SOURCE_TIBBER = "Tibber"
 
 # configuration options for net price calculation
 CONF_SURCHARGE_PERC = "percentage_surcharge"

--- a/custom_components/epex_spot/test_tibber.py
+++ b/custom_components/epex_spot/test_tibber.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+from EPEXSpot import Tibber
+
+service = Tibber.Tibber(market_area="de")
+print(service.MARKET_AREAS)
+
+service.fetch()
+print(f"count = {len(service.marketdata)}")
+for e in service.marketdata:
+    print(f"{e.start_time}: {e.price_ct_per_kwh} {e.UOM_CT_PER_kWh}")


### PR DESCRIPTION
This PR adds support for Tibber as the source of electricity prices. You need to have an account with Tibber and you also need to get an access token for their API from https://developer.tibber.com

### Motivation:
I thought it'd be nice to be able to
- see the future prices for Tibber (their HA integration only provides the current hour)
- be able to compare Tibber to EPEX spot prices and maybe competitors too

### Minor issue
I found no easy way to disable the configuration of `tax`, `percentage surcharge` and `absolute surcharge`. Those aren't needed for Tibber since they already provide net prices for the current customer as identified through the API token. If given, those values are silently ignored for Tibber.