### PR TITLE
Migrate user options to reflect change from ct/kWh to currency/kWh

### DIFF
--- a/custom_components/epex_spot/config_flow.py
+++ b/custom_components/epex_spot/config_flow.py
@@ -2,7 +2,9 @@
 
 Used by UI to setup integration.
 """
+
 import voluptuous as vol
+
 from homeassistant import config_entries
 from homeassistant.core import callback
 
@@ -18,12 +20,13 @@ from .const import (
     CONF_SURCHARGE_PERC,
     CONF_TAX,
     CONF_TOKEN,
+    CONFIG_VERSION,
     DEFAULT_SURCHARGE_ABS,
     DEFAULT_SURCHARGE_PERC,
     DEFAULT_TAX,
     DOMAIN,
 )
-from .EPEXSpot import SMARD, Awattar, EPEXSpotWeb, smartENERGY, Tibber
+from .EPEXSpot import SMARD, Awattar, EPEXSpotWeb, Tibber, smartENERGY
 
 CONF_SOURCE_LIST = (
     CONF_SOURCE_AWATTAR,
@@ -37,7 +40,7 @@ CONF_SOURCE_LIST = (
 class EpexSpotConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore
     """Component config flow."""
 
-    VERSION = 1
+    VERSION = CONFIG_VERSION
 
     def __init__(self):
         self._source_name = None

--- a/custom_components/epex_spot/const.py
+++ b/custom_components/epex_spot/const.py
@@ -13,6 +13,7 @@ ATTR_RANK = "rank"
 ATTR_QUANTILE = "quantile"
 ATTR_PRICE_PER_KWH = "price_per_kwh"
 
+CONFIG_VERSION = 2
 CONF_SOURCE = "source"
 CONF_MARKET_AREA = "market_area"
 CONF_TOKEN = "token"


### PR DESCRIPTION
This PR completes the transition to the new currency/kWh format by upgrading user options that were still in the ct/kWh unit. 