### PR TITLE
Fix migration error for user options

### DIFF
--- a/custom_components/epex_spot/__init__.py
+++ b/custom_components/epex_spot/__init__.py
@@ -210,6 +210,8 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         )
         new_options = {**config_entry.options}
 
+        new_options[CONF_SURCHARGE_ABS] *= 0.01
+
         hass.config_entries.async_update_entry(
             config_entry, options=new_options, version=CONFIG_VERSION
         )


### PR DESCRIPTION
Migration of user options did not work correctly as the surcharge was never recalculated.