### PR TITLE
Fix epex spot web scraper url

### DIFF
--- a/custom_components/epex_spot/EPEXSpot/EPEXSpotWeb/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/EPEXSpotWeb/__init__.py
@@ -69,7 +69,7 @@ class Marketprice:
 
 
 class EPEXSpotWeb:
-    URL = "https://www.epexspot.com/en/market-data"
+    URL = "https://www.epexspot.com/en/market-results"
 
     MARKET_AREAS = (
         "AT",
@@ -196,7 +196,7 @@ class EPEXSpotWeb:
         }
 
         async with self._session.post(
-            self.URL, headers=headers, params=params, data=data, verify_ssl=False
+            self.URL, headers=headers, params=params, data=data, verify_ssl=True
         ) as resp:
             resp.raise_for_status()
             return await resp.json()


### PR DESCRIPTION
The EPEX Spot data url seems to have been changed. This PR solves the issue.