### PR TITLE
Adding Energyforecast.de as a data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ You can choose between multiple sources:
 4. smartENERGY.at
    [smartENERGY.at](https://www.smartenergy.at/api-schnittstellen) provides a free of charge service for their customers. Market price data is available for Austria. So far no user identifiation is required.
 
+5. Energyforecast.de
+   [Energyforecast.de](https://www.energyforecast.de/api-docs/index.html) provides services to get Market price data forecasts for Germany up to 96 hours into the future. A api token is required.
+
 If you like this component, please give it a star on [github](https://github.com/mampfes/hacs_epex_spot).
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can choose between multiple sources:
    [smartENERGY.at](https://www.smartenergy.at/api-schnittstellen) provides a free of charge service for their customers. Market price data is available for Austria. So far no user identifiation is required.
 
 5. Energyforecast.de
-   [Energyforecast.de](https://www.energyforecast.de/api-docs/index.html) provides services to get Market price data forecasts for Germany up to 96 hours into the future. A api token is required.
+   [Energyforecast.de](https://www.energyforecast.de/api-docs/index.html) provides services to get market price data forecasts for Germany up to 96 hours into the future. An API token is required.
 
 If you like this component, please give it a star on [github](https://github.com/mampfes/hacs_epex_spot).
 

--- a/custom_components/epex_spot/EPEXSpot/Energyforecast/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/Energyforecast/__init__.py
@@ -5,7 +5,6 @@ import logging
 
 import aiohttp
 
-from homeassistant.util import dt as dt_util
 
 from ...const import UOM_EUR_PER_KWH
 

--- a/custom_components/epex_spot/EPEXSpot/Energyforecast/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/Energyforecast/__init__.py
@@ -16,13 +16,12 @@ class Marketprice:
     """Marketprice class for Energyforecast."""
 
     def __init__(self, data):
-        assert data["unit"].lower() == EUR_PER_MWH.lower()
         self._start_time = datetime.fromisoformat(data["start"])
         self._end_time = datetime.fromisoformat(data["end"])
         self._price_per_kwh = round(float(data["price"]), 6)
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(start: {self._start_time.isoformat()}, end: {self._end_time.isoformat()}, price: {self._price_per_kwh} {UOM_EUR_PER_KWH})" 
+        return f"{self.__class__.__name__}(start: {self._start_time.isoformat()}, end: {self._end_time.isoformat()}, marketprice: {self._price_per_kwh} {UOM_EUR_PER_KWH})" 
 
     @property
     def start_time(self):

--- a/custom_components/epex_spot/EPEXSpot/Energyforecast/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/Energyforecast/__init__.py
@@ -72,7 +72,7 @@ class Energyforecast:
 
     async def _fetch_data(self, url):
         async with self._session.get(
-            url, params={"token": self._token}
+            url, params={"token": self._token, "fixed_cost_cent": 0, "vat": 0}
         ) as resp:
             resp.raise_for_status()
             return await resp.json()

--- a/custom_components/epex_spot/EPEXSpot/Energyforecast/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/Energyforecast/__init__.py
@@ -36,15 +36,10 @@ class Marketprice:
     def price_per_kwh(self):
         return self._price_per_kwh
 
-
-def toEpochMilliSec(dt: datetime) -> int:
-    return int(dt.timestamp() * 1000)
-
-
 class Energyforecast:
     URL = "https://www.energyforecast.de/api/v1/predictions/next_96_hours"
 
-    MARKET_AREAS = ("de")
+    MARKET_AREAS = ("de",)
 
     def __init__(self, market_area, token: str, session: aiohttp.ClientSession):
         self._token = token

--- a/custom_components/epex_spot/EPEXSpot/Energyforecast/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/Energyforecast/__init__.py
@@ -1,0 +1,87 @@
+"""Energyforecast.de"""
+
+from datetime import datetime
+import logging
+
+import aiohttp
+
+from homeassistant.util import dt as dt_util
+
+from ...const import EUR_PER_MWH, UOM_EUR_PER_KWH
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Marketprice:
+    """Marketprice class for Energyforecast."""
+
+    def __init__(self, data):
+        assert data["unit"].lower() == EUR_PER_MWH.lower()
+        self._start_time = datetime.fromisoformat(data["start"])
+        self._end_time = datetime.fromisoformat(data["end"])
+        self._price_per_kwh = round(float(data["price"]), 6)
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(start: {self._start_time.isoformat()}, end: {self._end_time.isoformat()}, price: {self._price_per_kwh} {UOM_EUR_PER_KWH})" 
+
+    @property
+    def start_time(self):
+        return self._start_time
+
+    @property
+    def end_time(self):
+        return self._end_time
+
+    @property
+    def price_per_kwh(self):
+        return self._price_per_kwh
+
+
+def toEpochMilliSec(dt: datetime) -> int:
+    return int(dt.timestamp() * 1000)
+
+
+class Energyforecast:
+    URL = "https://www.energyforecast.de/api/v1/predictions/next_96_hours"
+
+    def __init__(self, token: str, session: aiohttp.ClientSession):
+        self._token = token
+        self._session = session
+        self._marketdata = []
+
+    @property
+    def name(self):
+        return "Energyforecast API V1"
+
+    @property
+    def market_area(self):
+        return self._market_area
+
+    @property
+    def duration(self):
+        return 60
+
+    @property
+    def currency(self):
+        return "EUR"
+
+    @property
+    def marketdata(self):
+        return self._marketdata
+
+    async def fetch(self):
+        data = await self._fetch_data(self.URL)
+        self._marketdata = self._extract_marketdata(data)
+
+    async def _fetch_data(self, url):
+        async with self._session.get(
+            url, params={"token": self._token}
+        ) as resp:
+            resp.raise_for_status()
+            return await resp.json()
+
+    def _extract_marketdata(self, data):
+        entries = []
+        for entry in data:
+            entries.append(Marketprice(entry))
+        return entries

--- a/custom_components/epex_spot/EPEXSpot/Energyforecast/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/Energyforecast/__init__.py
@@ -7,7 +7,7 @@ import aiohttp
 
 from homeassistant.util import dt as dt_util
 
-from ...const import CT_PER_KWH
+from ...const import UOM_EUR_PER_KWH
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,7 +21,7 @@ class Marketprice:
         self._price_per_kwh = round(float(data["price"]), 6)
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(start: {self._start_time.isoformat()}, end: {self._end_time.isoformat()}, marketprice: {self._price_per_kwh} {CT_PER_KWH})"  # noqa: E501
+        return f"{self.__class__.__name__}(start: {self._start_time.isoformat()}, end: {self._end_time.isoformat()}, marketprice: {self._price_per_kwh} {UOM_EUR_PER_KWH})"  # noqa: E501
 
     @property
     def start_time(self):

--- a/custom_components/epex_spot/EPEXSpot/Energyforecast/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/Energyforecast/__init__.py
@@ -77,7 +77,4 @@ class Energyforecast:
             return await resp.json()
 
     def _extract_marketdata(self, data):
-        entries = []
-        for entry in data:
-            entries.append(Marketprice(entry))
-        return entries
+        return [Marketprice(entry) for entry in data]

--- a/custom_components/epex_spot/EPEXSpot/Energyforecast/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/Energyforecast/__init__.py
@@ -7,7 +7,7 @@ import aiohttp
 
 from homeassistant.util import dt as dt_util
 
-from ...const import EUR_PER_MWH, UOM_EUR_PER_KWH
+from ...const import CT_PER_KWH
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,7 +21,7 @@ class Marketprice:
         self._price_per_kwh = round(float(data["price"]), 6)
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(start: {self._start_time.isoformat()}, end: {self._end_time.isoformat()}, marketprice: {self._price_per_kwh} {UOM_EUR_PER_KWH})" 
+        return f"{self.__class__.__name__}(start: {self._start_time.isoformat()}, end: {self._end_time.isoformat()}, marketprice: {self._price_per_kwh} {CT_PER_KWH})"  # noqa: E501
 
     @property
     def start_time(self):

--- a/custom_components/epex_spot/EPEXSpot/Energyforecast/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/Energyforecast/__init__.py
@@ -36,7 +36,7 @@ class Marketprice:
         return self._price_per_kwh
 
 class Energyforecast:
-    URL = "https://www.energyforecast.de/api/v1/predictions/next_96_hours"
+    URL = "https://www.energyforecast.de/api/v1/predictions/prices_for_ha"
 
     MARKET_AREAS = ("de",)
 
@@ -68,7 +68,7 @@ class Energyforecast:
 
     async def fetch(self):
         data = await self._fetch_data(self.URL)
-        self._marketdata = self._extract_marketdata(data)
+        self._marketdata = self._extract_marketdata(data["forecast"]["data"])
 
     async def _fetch_data(self, url):
         async with self._session.get(

--- a/custom_components/epex_spot/EPEXSpot/Energyforecast/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/Energyforecast/__init__.py
@@ -44,9 +44,12 @@ def toEpochMilliSec(dt: datetime) -> int:
 class Energyforecast:
     URL = "https://www.energyforecast.de/api/v1/predictions/next_96_hours"
 
-    def __init__(self, token: str, session: aiohttp.ClientSession):
+    MARKET_AREAS = ("de")
+
+    def __init__(self, market_area, token: str, session: aiohttp.ClientSession):
         self._token = token
         self._session = session
+        self._market_area = market_area
         self._marketdata = []
 
     @property

--- a/custom_components/epex_spot/SourceShell.py
+++ b/custom_components/epex_spot/SourceShell.py
@@ -71,7 +71,9 @@ class SourceShell:
             )
         elif config_entry.data[CONF_SOURCE] == CONF_SOURCE_ENERGYFORECAST:
             self._source = Energyforecast.Energyforecast(
-                token=self._config_entry.data[CONF_TOKEN], session=session
+                market_area=config_entry.data[CONF_MARKET_AREA],
+                token=self._config_entry.data[CONF_TOKEN],
+                session=session
             )
 
     @property

--- a/custom_components/epex_spot/SourceShell.py
+++ b/custom_components/epex_spot/SourceShell.py
@@ -22,6 +22,7 @@ from .const import (
     CONF_SOURCE_SMARD_DE,
     CONF_SOURCE_SMARTENERGY,
     CONF_SOURCE_TIBBER,
+    CONF_SOURCE_ENERGYFORECAST,
     CONF_SURCHARGE_ABS,
     CONF_SURCHARGE_PERC,
     CONF_TAX,
@@ -31,7 +32,7 @@ from .const import (
     DEFAULT_TAX,
     EMPTY_EXTREME_PRICE_INTERVAL_RESP,
 )
-from .EPEXSpot import SMARD, Awattar, EPEXSpotWeb, Tibber, smartENERGY
+from .EPEXSpot import SMARD, Awattar, EPEXSpotWeb, Tibber, smartENERGY, Energyforecast
 from .extreme_price_interval import find_extreme_price_interval, get_start_times
 
 _LOGGER = logging.getLogger(__name__)
@@ -67,6 +68,10 @@ class SourceShell:
                 market_area=config_entry.data[CONF_MARKET_AREA],
                 token=self._config_entry.data[CONF_TOKEN],
                 session=session,
+            )
+        elif config_entry.data[CONF_SOURCE] == CONF_SOURCE_ENERGYFORECAST:
+            self._source = Energyforecast.Energyforecast(
+                token=self._config_entry.data[CONF_TOKEN], session=session
             )
 
     @property

--- a/custom_components/epex_spot/config_flow.py
+++ b/custom_components/epex_spot/config_flow.py
@@ -16,6 +16,7 @@ from .const import (
     CONF_SOURCE_SMARD_DE,
     CONF_SOURCE_SMARTENERGY,
     CONF_SOURCE_TIBBER,
+    CONF_SOURCE_ENERGYFORECAST,
     CONF_SURCHARGE_ABS,
     CONF_SURCHARGE_PERC,
     CONF_TAX,
@@ -34,6 +35,7 @@ CONF_SOURCE_LIST = (
     CONF_SOURCE_SMARD_DE,
     CONF_SOURCE_SMARTENERGY,
     CONF_SOURCE_TIBBER,
+    CONF_SOURCE_ENERGYFORECAST,
 )
 
 
@@ -78,6 +80,11 @@ class EpexSpotConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ign
                     vol.Required(CONF_MARKET_AREA): vol.In(sorted(areas)),
                     vol.Required(CONF_TOKEN): vol.Coerce(str),
                 }
+            )
+        # Energyforecast API requires a token
+        elif self._source_name == CONF_SOURCE_ENERGYFORECAST:
+            data_schema = vol.Schema(
+                {vol.Required(CONF_TOKEN): vol.Coerce(str)}
             )
         else:
             if self._source_name == CONF_SOURCE_AWATTAR:

--- a/custom_components/epex_spot/config_flow.py
+++ b/custom_components/epex_spot/config_flow.py
@@ -84,7 +84,10 @@ class EpexSpotConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ign
         # Energyforecast API requires a token
         elif self._source_name == CONF_SOURCE_ENERGYFORECAST:
             data_schema = vol.Schema(
-                {vol.Required(CONF_TOKEN): vol.Coerce(str)}
+                {
+                    vol.Required(CONF_MARKET_AREA): vol.In(sorted(areas)),
+                    vol.Required(CONF_TOKEN): vol.Coerce(str)
+                }
             )
         else:
             if self._source_name == CONF_SOURCE_AWATTAR:

--- a/custom_components/epex_spot/config_flow.py
+++ b/custom_components/epex_spot/config_flow.py
@@ -27,7 +27,7 @@ from .const import (
     DEFAULT_TAX,
     DOMAIN,
 )
-from .EPEXSpot import SMARD, Awattar, EPEXSpotWeb, Tibber, smartENERGY
+from .EPEXSpot import SMARD, Awattar, EPEXSpotWeb, Tibber, smartENERGY, Energyforecast
 
 CONF_SOURCE_LIST = (
     CONF_SOURCE_AWATTAR,
@@ -83,6 +83,7 @@ class EpexSpotConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ign
             )
         # Energyforecast API requires a token
         elif self._source_name == CONF_SOURCE_ENERGYFORECAST:
+            areas = Energyforecast.Energyforecast.MARKET_AREAS
             data_schema = vol.Schema(
                 {
                     vol.Required(CONF_MARKET_AREA): vol.In(sorted(areas)),

--- a/custom_components/epex_spot/const.py
+++ b/custom_components/epex_spot/const.py
@@ -24,6 +24,7 @@ CONF_SOURCE_EPEX_SPOT_WEB = "EPEX Spot Web Scraper"
 CONF_SOURCE_SMARD_DE = "SMARD.de"
 CONF_SOURCE_SMARTENERGY = "smartENERGY.at"
 CONF_SOURCE_TIBBER = "Tibber"
+CONF_SOURCE_ENERGYFORECAST = "Energyforecast.de"
 
 # configuration options for net price calculation
 CONF_SURCHARGE_PERC = "percentage_surcharge"

--- a/custom_components/epex_spot/test_energyforecast.py
+++ b/custom_components/epex_spot/test_energyforecast.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+import aiohttp
+import asyncio
+
+from .EPEXSpot import Energyforecast
+from .const import UOM_EUR_PER_KWH
+
+DEMO_TOKEN = "test"
+
+
+async def main():
+    async with aiohttp.ClientSession() as session:
+        service = Energyforecast.Energyforecast(token=DEMO_TOKEN, session=session)
+
+        await service.fetch()
+        print(f"count = {len(service.marketdata)}")
+        for e in service.marketdata:
+            print(f"{e.start_time}: {e.price_per_kwh} {UOM_EUR_PER_KWH}")
+
+
+asyncio.run(main())

--- a/custom_components/epex_spot/test_energyforecast.py
+++ b/custom_components/epex_spot/test_energyforecast.py
@@ -6,12 +6,11 @@ import asyncio
 from .EPEXSpot import Energyforecast
 from .const import UOM_EUR_PER_KWH
 
-DEMO_TOKEN = "test"
-
+DEMO_TOKEN = "demo_token" # The "demo_token" token only provides up to 24 hours of forecast data into the future.
 
 async def main():
     async with aiohttp.ClientSession() as session:
-        service = Energyforecast.Energyforecast(token=DEMO_TOKEN, session=session)
+        service = Energyforecast.Energyforecast(market_area="DE-LU", token=DEMO_TOKEN, session=session)
 
         await service.fetch()
         print(f"count = {len(service.marketdata)}")


### PR DESCRIPTION
As discussed in [This issue](https://github.com/mampfes/ha_epex_spot/issues/146) I added a Integration for my energy price forecast site. Hope this helps to bring energy price forecasts to many users and in their smart home. For now only DE prices are supported.

This is how it looks like with Apex Charts:
<img width="502" alt="image" src="https://github.com/user-attachments/assets/e67ca40a-0d1e-44f8-ace5-1169d4cefee2">
