### PR TITLE
Fix migrate

### DIFF
--- a/custom_components/epex_spot/__init__.py
+++ b/custom_components/epex_spot/__init__.py
@@ -210,7 +210,13 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         )
         new_options = {**config_entry.options}
 
-        new_options[CONF_SURCHARGE_ABS] *= 0.01
+        if (
+            CONF_SURCHARGE_ABS in config_entry.options
+            and config_entry.options[CONF_SURCHARGE_ABS] is not None
+        ):
+            new_options[CONF_SURCHARGE_ABS] = (
+                config_entry.options[CONF_SURCHARGE_ABS] * 0.01
+            )
 
         hass.config_entries.async_update_entry(
             config_entry, options=new_options, version=CONFIG_VERSION

--- a/custom_components/epex_spot/config_flow.py
+++ b/custom_components/epex_spot/config_flow.py
@@ -87,7 +87,7 @@ class EpexSpotConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ign
             data_schema = vol.Schema(
                 {
                     vol.Required(CONF_MARKET_AREA): vol.In(sorted(areas)),
-                    vol.Required(CONF_TOKEN): vol.Coerce(str)
+                    vol.Required(CONF_TOKEN): vol.Coerce(str),
                 }
             )
         else:
@@ -124,6 +124,7 @@ class EpexSpotConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ign
                 title=title,
                 data=data,
             )
+        return None
 
     @staticmethod
     @callback


### PR DESCRIPTION
Migrating to `3.0.0` fails if user options have never been changed.