### PR TITLE
Add Hofer Gruenstrom API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ You can choose between multiple sources:
 5. Energyforecast.de
    [Energyforecast.de](https://www.energyforecast.de/api-docs/index.html) provides services to get market price data forecasts for Germany up to 96 hours into the future. An API token is required.
 
+6. Hofer Grünstrom
+   [Hofer Grünstrom](https://www.hofer-grünstrom.at/tarife-zum-geld-sparen#spot) has an open API for accessing market data for Austria. So far no user identifiation is required. (This API is not officially documented, but was discovered by reverse engineering the Hofer Grünstrom website.)
+
 If you like this component, please give it a star on [github](https://github.com/mampfes/hacs_epex_spot).
 
 ## Installation

--- a/custom_components/epex_spot/EPEXSpot/HoferGruenstrom/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/HoferGruenstrom/__init__.py
@@ -1,0 +1,126 @@
+"""Hofer Gruenstrom API."""
+
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+import logging
+
+import aiohttp
+
+from ...const import TIMEZONE_HOFER_GRUENSTROM
+from custom_components.epex_spot import const
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _set_tz_on_date(date):
+    """Set timezone on a date object."""
+    timezone = ZoneInfo(TIMEZONE_HOFER_GRUENSTROM)
+
+    if date.tzinfo is None:
+        return date.replace(tzinfo=timezone)
+
+    return date.astimezone(timezone)
+
+
+class Marketprice:
+    """Marketprice class for Hofer Gruenstrom."""
+
+    def __init__(self, data):
+        self._from = datetime.fromisoformat(data["from"])
+        self._to = datetime.fromisoformat(data["to"])
+        # price does not include vat or other taxes, so it is already in the correct format
+        self._price = round(float(data["price"]) / 100, 6)
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(start: {self._from.isoformat()}, "
+            f"end: {self._to.isoformat()}, price: {self._price} {const.CT_PER_KWH})"
+        )
+
+    @property
+    def start_time(self):
+        return _set_tz_on_date(self._from)
+
+    @property
+    def end_time(self):
+        return _set_tz_on_date(self._to)
+
+    @property
+    def price_per_kwh(self):
+        return self._price
+
+
+class HoferGruenstrom:
+    URL = "https://www.xn--hofer-grnstrom-nsb.at/service/energy-manager/spot-prices"
+
+    MARKET_AREAS = ("at",)
+
+    def __init__(self, market_area, session: aiohttp.ClientSession):
+        self._session = session
+        self._market_area = market_area
+        self._duration = 15  # default value, can be overwritten by API response
+        self._marketdata = []
+
+    @property
+    def name(self):
+        return "Hofer Gruenstrom API"
+
+    @property
+    def market_area(self):
+        return self._market_area
+
+    @property
+    def duration(self):
+        return self._duration
+
+    @property
+    def currency(self):
+        return "EUR"
+
+    @property
+    def marketdata(self):
+        return self._marketdata
+
+    async def fetch(self):
+        # get todays and tomorrows date components
+        today = datetime.now()
+        tomorrow = today + timedelta(days=1)
+        dates = [today, tomorrow]
+
+        # fetch data for today and tomorrow
+
+        marketdata = []
+        for date in dates:
+            raw_data = await self._fetch_data_for_date(date)
+            if raw_data is None:
+                continue
+
+            # get the data key from the response
+            data = raw_data.get("data")
+            if not data:
+                _LOGGER.error("No data found in response for %s", date.isoformat())
+                continue
+            # extract market data
+            for item in data:
+                if not item.get("from") or not item.get("to") or not item.get("price"):
+                    _LOGGER.warning("Skipping item with missing fields: %s", item)
+                    continue
+                # create Marketprice instance
+                marketdata.append(Marketprice(item))
+
+        self._marketdata = marketdata
+
+    async def _fetch_data_for_date(self, date):
+        """Fetch data for a specific date."""
+        url = f"{self.URL}?year={date.year}&month={date.month}&day={date.day}"
+        async with self._session.get(url) as response:
+            if response.status != 200:
+                if response.status == 204:
+                    _LOGGER.debug("No data available for %s yet.", date.isoformat())
+                    return None
+                _LOGGER.error(
+                    "Failed to fetch data from Hofer Gruenstrom API: %s",
+                    response.status,
+                )
+                return None
+            return await response.json()

--- a/custom_components/epex_spot/SourceShell.py
+++ b/custom_components/epex_spot/SourceShell.py
@@ -23,6 +23,7 @@ from .const import (
     CONF_SOURCE_SMARD_DE,
     CONF_SOURCE_SMARTENERGY,
     CONF_SOURCE_TIBBER,
+    CONF_SOURCE_HOFER_GRUENSTROM,
     CONF_SURCHARGE_ABS,
     CONF_SURCHARGE_PERC,
     CONF_TAX,
@@ -32,7 +33,15 @@ from .const import (
     DEFAULT_TAX,
     EMPTY_EXTREME_PRICE_INTERVAL_RESP,
 )
-from .EPEXSpot import SMARD, Awattar, Energyforecast, EPEXSpotWeb, Tibber, smartENERGY
+from .EPEXSpot import (
+    SMARD,
+    Awattar,
+    Energyforecast,
+    EPEXSpotWeb,
+    Tibber,
+    smartENERGY,
+    HoferGruenstrom,
+)
 from .extreme_price_interval import find_extreme_price_interval, get_start_times
 
 _LOGGER = logging.getLogger(__name__)
@@ -74,6 +83,10 @@ class SourceShell:
                 market_area=config_entry.data[CONF_MARKET_AREA],
                 token=self._config_entry.data[CONF_TOKEN],
                 session=session,
+            )
+        elif config_entry.data[CONF_SOURCE] == CONF_SOURCE_HOFER_GRUENSTROM:
+            self._source = HoferGruenstrom.HoferGruenstrom(
+                market_area=config_entry.data[CONF_MARKET_AREA], session=session
             )
 
     @property

--- a/custom_components/epex_spot/config_flow.py
+++ b/custom_components/epex_spot/config_flow.py
@@ -17,6 +17,7 @@ from .const import (
     CONF_SOURCE_SMARTENERGY,
     CONF_SOURCE_TIBBER,
     CONF_SOURCE_ENERGYFORECAST,
+    CONF_SOURCE_HOFER_GRUENSTROM,
     CONF_SURCHARGE_ABS,
     CONF_SURCHARGE_PERC,
     CONF_TAX,
@@ -27,7 +28,7 @@ from .const import (
     DEFAULT_TAX,
     DOMAIN,
 )
-from .EPEXSpot import SMARD, Awattar, EPEXSpotWeb, Tibber, smartENERGY, Energyforecast
+from .EPEXSpot import SMARD, Awattar, EPEXSpotWeb, Tibber, smartENERGY, Energyforecast, HoferGruenstrom
 
 CONF_SOURCE_LIST = (
     CONF_SOURCE_AWATTAR,
@@ -36,6 +37,7 @@ CONF_SOURCE_LIST = (
     CONF_SOURCE_SMARTENERGY,
     CONF_SOURCE_TIBBER,
     CONF_SOURCE_ENERGYFORECAST,
+    CONF_SOURCE_HOFER_GRUENSTROM,
 )
 
 
@@ -99,7 +101,8 @@ class EpexSpotConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ign
                 areas = SMARD.SMARD.MARKET_AREAS
             elif self._source_name == CONF_SOURCE_SMARTENERGY:
                 areas = smartENERGY.smartENERGY.MARKET_AREAS
-
+            elif self._source_name == CONF_SOURCE_HOFER_GRUENSTROM:
+                areas = HoferGruenstrom.HoferGruenstrom.MARKET_AREAS
             data_schema = vol.Schema(
                 {vol.Required(CONF_MARKET_AREA): vol.In(sorted(areas))}
             )

--- a/custom_components/epex_spot/const.py
+++ b/custom_components/epex_spot/const.py
@@ -25,6 +25,7 @@ CONF_SOURCE_SMARD_DE = "SMARD.de"
 CONF_SOURCE_SMARTENERGY = "smartENERGY.at"
 CONF_SOURCE_TIBBER = "Tibber"
 CONF_SOURCE_ENERGYFORECAST = "Energyforecast.de"
+CONF_SOURCE_HOFER_GRUENSTROM = "Hofer Gruenstrom"
 
 # configuration options for net price calculation
 CONF_SURCHARGE_PERC = "percentage_surcharge"
@@ -48,6 +49,8 @@ EMPTY_EXTREME_PRICE_INTERVAL_RESP = {
     "price_per_kwh": None,
     "net_price_per_kwh": None,
 }
+
+TIMEZONE_HOFER_GRUENSTROM = "Europe/Vienna"
 
 UOM_EUR_PER_KWH = "€/kWh"
 UOM_MWH = "MWh"

--- a/custom_components/epex_spot/test_hofer_gruenstrom.py
+++ b/custom_components/epex_spot/test_hofer_gruenstrom.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+import asyncio
+
+import aiohttp
+
+from .const import UOM_EUR_PER_KWH
+from .EPEXSpot import HoferGruenstrom
+
+
+async def main():
+    async with aiohttp.ClientSession() as session:
+        service = HoferGruenstrom.HoferGruenstrom(market_area="at", session=session)
+
+        await service.fetch()
+        print(f"count = {len(service.marketdata)}")
+        for e in service.marketdata:
+            print(f"{e.start_time}-{e.end_time}: {e.price_per_kwh} {UOM_EUR_PER_KWH}")
+
+
+asyncio.run(main())


### PR DESCRIPTION
This PR adds the unofficial Hofer Grünstrom API which is publicly available on [this website](https://www.hofer-grünstrom.at/tarife-zum-geld-sparen#spot)

The API provides data for each day in 15 minutes intervals, and has data ready for the upcoming day at around 14:00.

For more information have a look at the corresponding issue: #213 

