### PR TITLE
Align Tibber price retrieval with the other methods: get the net price.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,31 @@ To get the actual, current gross price [listed by smartENERGY on their website](
 - Absolute surcharge = €0.012
 - Tax = 20%
 
+> [!NOTE] Tibber
+
+Before version 3.1.0 the integration pulled gross prices only from Tibber. The net price value was also set to the gross price, and settings for surcharges and tax were ignored.
+
+Since version 3.1.0 ony the net price is fetched from Tibber, to align the behavior of this service with the other providers. Hence individual surcharges and tax values have to be configured individually, and - as breaking change - the use of the former sensors `price` and `net_price` in automations, scripts, templates, and dashboards that reference these sensors will need to be updated accordingly to reflect the new names. This step has to be taken anyway to reflect the general change from `net_price` to `gross_price` and `price` to `net_price`.
+
+Setting of surcharge and tax is required for the correct calculation of the gross price. Tibber charges no percentual surcharge, set this value to "0". You can summarize the absolute surcharges from your monthly bill. The PDF version of the bill lists these values on page 2. From the table presented there add all items except the first line ("Strom-Börsenpreis" in german) and use the result as surcharge in €/kWh. As tax please add your local VAT.
+
+Example from the bill, page 2 (german):
+
+| Stromeinkauf |  |  |
+|---|---:|---:|
+| Strom-Börsenpreis | 5,64 ct/kWh | 0,50 € |
+| Weitere Beschaffungskosten (s. §4 AGB) | 1,81 ct/kWh | 0,16 € |
+| Netz |  |  |
+| Netznutzungsentgelt (variabel) | 6,05 ct/kWh | 0,54 € |
+| Steuern, Abgaben & Umlagen |  |  |
+| Konzessionsabgabe | 2,39 ct/kWh | 0,21 € |
+| Stromsteuer | 2,05 ct/kWh | 0,19 € |
+| Offshore Wind Umlage | 0,816 ct/kWh | 0,08 € |
+| KWK Umlage | 0,277 ct/kWh | 0,03 € |
+| Strom NEV Umlage | 1,56 ct/kWh | 0,13 € |
+
+In this example add `1,81 + 6,05 + 2,39 + 2,05 + 0,816 + 0,277 + 1,56`, get `14.953` as result and enter `0.14953` as absolute surcharge in €/kWh.
+
 ### 2. Net Market Price Sensor
 
 The sensor value reports the EPEX Spot net market price in €/£/kWh. The net market price doesn't include taxes, surcharges, VAT. The price value will be updated every hour to reflect the current market price.

--- a/custom_components/epex_spot/EPEXSpot/Tibber/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/Tibber/__init__.py
@@ -14,18 +14,12 @@ TIBBER_QUERY = """
       currentSubscription {
         priceInfo(resolution: {resolution}) {
           today {
-            total
             energy
-            tax
             startsAt
-            currency
           }
           tomorrow {
-            total
             energy
-            tax
             startsAt
-            currency
           }
         }
       }
@@ -101,7 +95,7 @@ class Tibber:
                 Marketprice(
                     duration=self._duration,
                     start_time=datetime.fromisoformat(entry["startsAt"]),
-                    price=round(float(entry["total"]), 6),
+                    price=round(float(entry["energy"]), 6),
                     unit=UOM_EUR_PER_KWH,
                 )
             )
@@ -110,7 +104,7 @@ class Tibber:
                 Marketprice(
                     duration=self._duration,
                     start_time=datetime.fromisoformat(entry["startsAt"]),
-                    price=round(float(entry["total"]), 6),
+                    price=round(float(entry["energy"]), 6),
                     unit=UOM_EUR_PER_KWH,
                 )
             )

--- a/custom_components/epex_spot/SourceShell.py
+++ b/custom_components/epex_spot/SourceShell.py
@@ -163,21 +163,19 @@ class SourceShell:
     def to_gross_price(self, net_price_per_kwh):
         net_p = net_price_per_kwh
 
-        # Standard calculation for other cases
-        if "Tibber API" not in self.name:
-            # Retrieve tax and surcharge values from config
-            surcharge_abs = self._config_entry.options.get(
-                CONF_SURCHARGE_ABS, DEFAULT_SURCHARGE_ABS
-            )
-            tax = self._config_entry.options.get(CONF_TAX, DEFAULT_TAX)
+        # Retrieve tax and surcharge values from config
+        surcharge_abs = self._config_entry.options.get(
+            CONF_SURCHARGE_ABS, DEFAULT_SURCHARGE_ABS
+        )
+        tax = self._config_entry.options.get(CONF_TAX, DEFAULT_TAX)
 
-            surcharge_pct = self._config_entry.options.get(
-                CONF_SURCHARGE_PERC, DEFAULT_SURCHARGE_PERC
-            )
+        surcharge_pct = self._config_entry.options.get(
+            CONF_SURCHARGE_PERC, DEFAULT_SURCHARGE_PERC
+        )
 
-            net_p = net_p + abs(net_p) * surcharge_pct / 100
-            net_p += surcharge_abs
-            net_p *= 1 + (tax / 100.0)
+        net_p = net_p + abs(net_p) * surcharge_pct / 100
+        net_p += surcharge_abs
+        net_p *= 1 + (tax / 100.0)
 
         return round(net_p, 6)
 


### PR DESCRIPTION
Tibber's API makes several values directly accessible, gross price (total), net price (energy), all added rates including tax (tax), and the currency. The integration currently requests all data, but uses only "total" - the gross price.

To align the Tibber function this pull request modifies the behaviour:
- request only "energy" (net price)
- remove the special treatment of "Tibber API" in not generating the gross price

This in turn means, that an update would require all users to set the surchage and tax value in the configuration. Surchrage can be obtained from the monthly bill in PDF form, on page two there are several items listed apart from the average market price. Add all remaining values, and insert the sum as absolute surcharge. No percentage surchage (set value to 0).

In 2025 in Bremen, Germany, this absolute surcharge amounts to 0.14953€/kWh.