### PR TITLE
Rename gross and net price sensors to total and market price

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ In case you would like to install manually:
 
 This integration provides the following sensors:
 
-1. Gross market price
-2. Net market price
+1. Total price
+2. Market price
 3. Average market price during the day
 4. Median market price during the day
 5. Lowest market price during the day
@@ -75,11 +75,11 @@ This integration provides the following sensors:
 
 NOTE: For GB data, the prices will be shown in GBP instead of EUR. The sensor attribute names are adjusted accordingly.
 
-### 1. Gross Market Price Sensor
+### 1. Total Price Sensor
 
-The sensor value reports the gross market price in €/£/kWh. The price value will be updated every hour to reflect the current gross market price.
+The sensor value reports the total market price in €/£/kWh. The price value will be updated every hour to reflect the current total market price.
 
-The sensor attributes contains a list of all available gross market prices (for today and tomorrow if available) in €/£/kWh.
+The sensor attributes contains a list of all available total market prices (for today and tomorrow if available) in €/£/kWh.
 
 ```yaml
 data:
@@ -94,11 +94,11 @@ data:
     price_per_kwh: 0.12247
 ```
 
-The gross market price will be calculated as follows:
-`<Gross Price>` = `<Net Price>` + `<Surcharges>` + `<Tax>`
+The total market price will be calculated as follows:
+`<Total Price>` = `<Market Price>` + `<Surcharges>` + `<Tax>`
 
-- Gross market price is the price you have to pay at the end, including taxes, surcharges and VAT.
-- Net price is the energy price from EPEX Spot excluding taxes, surcharges, VAT.
+- Total price is the price you have to pay at the end, including taxes, surcharges and VAT.
+- Market price is the energy price from EPEX Spot excluding taxes, surcharges, VAT.
 - 2 different types of surcharges can be adjusted:
   1. Percentage Surcharge, stated in % of the EPEX Spot market price.
   2. Absolute Surcharge, stated in €/£/kWh, excluding VAT.
@@ -113,29 +113,29 @@ Percentage Surchage = 3%
 Absolute Surcharge = 0.012 €/£/kWh
 Tax = 19%
 
-Gross Price = ((Net Price * 1.03) + 0.012) * 1.19
+Total Price = ((Market Price * 1.03) + 0.012) * 1.19
 ```
 
 > [!NOTE] smartENERGY.at
 
 As of Feb 2024, even though smartENERGY says that the prices reported by the API already include 20% tax (meaning users would configure the sensor to add a static €0.0144 to every price value from the API), [this is incorrect, and the API reports pricing without Tax](https://github.com/mampfes/ha_epex_spot/issues/108#issuecomment-1951423366 "this is incorrect, and the API reports pricing without Tax").
 
-To get the actual, current gross price [listed by smartENERGY on their website](https://www.smartenergy.at/smartcontrol#:~:text=Aktueller%20Stundenpreis "listed by smartENERGY on their website"), configure:
+To get the actual, current total price [listed by smartENERGY on their website](https://www.smartenergy.at/smartcontrol#:~:text=Aktueller%20Stundenpreis "listed by smartENERGY on their website"), configure:
 
 - Absolute surcharge = €0.012
 - Tax = 20%
 
-### 2. Net Market Price Sensor
+### 2. Market Price Sensor
 
-The sensor value reports the EPEX Spot net market price in €/£/kWh. The net market price doesn't include taxes, surcharges, VAT. The price value will be updated every hour to reflect the current market price.
+The sensor value reports the EPEX Spot market price in €/£/kWh. The market price doesn't include taxes, surcharges, VAT. The price value will be updated every selected period to reflect the current market price.
 
 The sensor attributes contains additional values:
 
-- The net market price in €/£/kWh.
+- The market price in €/£/kWh.
 - A list of all available market prices (for today and tomorrow if available) in €/£/kWh.
 
 ```yaml
-net_price_per_kwh: 0.089958
+market_price_per_kwh: 0.089958
 data:
   - start_time: "2022-12-15T23:00:00+00:00"
     end_time: "2022-12-16T00:00:00+00:00"
@@ -163,7 +163,7 @@ The sensor value reports the lowest EPEX Spot market price during the day. The s
 The sensor attributes contains the start and endtime of the lowest market price timeframe.
 
 ```yaml
-net_price_per_kwh: 0.09
+market_price_per_kwh: 0.09
 start_time: "2023-02-15T22:00:00+00:00"
 end_time: "2023-02-15T23:00:00+00:00"
 ```
@@ -295,8 +295,8 @@ Example:
 ```yaml
 start: "2024-11-04T23:00:00+01:00"
 end: "2024-11-05T00:00:00+01:00"
-net_price_per_kwh: 0.098192
-gross_price_per_kwh: 0.13223
+market_price_per_kwh: 0.098192
+total_price_per_kwh: 0.13223
 ```
 
 With Home Assistant release >= 2023.9 you can use the [Template Integration](https://www.home-assistant.io/integrations/template/) to create a sensor (in your `configuration.yaml` file) that shows the start time:
@@ -355,7 +355,7 @@ A significantly easier, GUI-based method to achieve some of the results listed a
 
 ### 1. How can I show a chart of the next hours?
 
-With [ApexCharts](https://github.com/RomRider/apexcharts-card), you can easily show a chart like this to see the hourly net prices for today:
+With [ApexCharts](https://github.com/RomRider/apexcharts-card), you can easily show a chart like this to see the hourly market prices for today:
 
 ![apexchart](/images/apexcharts.png)
 
@@ -373,7 +373,7 @@ now:
   show: true
   label: Now
 series:
-  - entity: sensor.epex_spot_data_gross_price
+  - entity: sensor.epex_spot_data_total_price
     name: Electricity Price
     type: column
     extend_to: end
@@ -387,11 +387,11 @@ See [this Show & Tell post](https://github.com/mampfes/ha_epex_spot/discussions/
 
 **Assumptions:**
 
-This example assumes that you are using smartENERGY.at as a source and want to display the Gross Price in €/kWh for the next 48 hours. The value for `entity` and the `entry` being processed by the `data_generator` are specific to this data source:
+This example assumes that you are using smartENERGY.at as a source and want to display the Total Price in €/kWh for the next 48 hours. The value for `entity` and the `entry` being processed by the `data_generator` are specific to this data source:
 
 ![Apex Chart Data Source Example](/images/apexcharts-entities-example.png)
 
-If you are using a different source, you will need to first update `sensor.epex_spot_data_gross_price` to use the correct sensor for your configuration (check which Entities you have available under Devices → Integrations → EPEX Spot → `#` Entities) and then change `entry.price_per_kwh` to the attribute that you want to use from your sensor of choice. If your data source does not report prices for the next day, you can change the `graph_span` to `24h` to get rid of the empty space that this configuration would create.
+If you are using a different source, you will need to first update `sensor.epex_spot_data_total_price` to use the correct sensor for your configuration (check which Entities you have available under Devices → Integrations → EPEX Spot → `#` Entities) and then change `entry.price_per_kwh` to the attribute that you want to use from your sensor of choice. If your data source does not report prices for the next day, you can change the `graph_span` to `24h` to get rid of the empty space that this configuration would create.
 
 ### 2. How can I optimise the best moment to start appliances?
 

--- a/custom_components/epex_spot/EPEXSpot/Awattar/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/Awattar/__init__.py
@@ -25,7 +25,7 @@ class AwattarMarketprice(Marketprice):
         self._end_time = datetime.fromtimestamp(
             data["end_timestamp"] / 1000, tz=timezone.utc
         )
-        self._net_price_per_kwh = round(float(data["marketprice"]) / 1000.0, 6)
+        self._market_price_per_kwh = round(float(data["marketprice"]) / 1000.0, 6)
         self._unit = UOM_EUR_PER_KWH
 
 

--- a/custom_components/epex_spot/EPEXSpot/Energyforecast/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/Energyforecast/__init__.py
@@ -17,10 +17,10 @@ class Marketprice:
     def __init__(self, data):
         self._start_time = datetime.fromisoformat(data["start"])
         self._end_time = datetime.fromisoformat(data["end"])
-        self._net_price_per_kwh = round(float(data["price"]), 6)
+        self._market_price_per_kwh = round(float(data["price"]), 6)
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(start: {self._start_time.isoformat()}, end: {self._end_time.isoformat()}, marketprice: {self._net_price_per_kwh} {UOM_EUR_PER_KWH})"  # noqa: E501
+        return f"{self.__class__.__name__}(start: {self._start_time.isoformat()}, end: {self._end_time.isoformat()}, marketprice: {self._market_price_per_kwh} {UOM_EUR_PER_KWH})"  # noqa: E501
 
     @property
     def start_time(self):
@@ -31,8 +31,8 @@ class Marketprice:
         return self._end_time
 
     @property
-    def net_price_per_kwh(self):
-        return self._net_price_per_kwh
+    def market_price_per_kwh(self):
+        return self._market_price_per_kwh
 
 
 class Energyforecast:

--- a/custom_components/epex_spot/SourceShell.py
+++ b/custom_components/epex_spot/SourceShell.py
@@ -170,12 +170,12 @@ class SourceShell:
             self.marketdata,
         )
         sorted_sorted_marketdata_today = sorted(
-            sorted_marketdata_today, key=lambda e: e.net_price_per_kwh
+            sorted_marketdata_today, key=lambda e: e.market_price_per_kwh
         )
         self._sorted_marketdata_today = sorted_sorted_marketdata_today
 
-    def to_gross_price(self, net_price_per_kwh):
-        gross_price = net_price_per_kwh
+    def to_total_price(self, market_price_per_kwh):
+        total_price = market_price_per_kwh
 
         # Standard calculation for other cases
         if "Tibber API" not in self.name:
@@ -189,11 +189,11 @@ class SourceShell:
                 CONF_SURCHARGE_PERC, DEFAULT_SURCHARGE_PERC
             )
 
-            gross_price = gross_price + abs(gross_price) * surcharge_pct / 100
-            gross_price += surcharge_abs
-            gross_price *= 1 + (tax / 100.0)
+            total_price = total_price + abs(total_price) * surcharge_pct / 100
+            total_price += surcharge_abs
+            total_price *= 1 + (tax / 100.0)
 
-        return round(gross_price, 6)
+        return round(total_price, 6)
 
     def find_extreme_price_interval(self, call_data, cmp):
         duration: timedelta = call_data[CONF_DURATION]
@@ -218,6 +218,6 @@ class SourceShell:
         return {
             "start": result["start"],
             "end": result["start"] + duration,
-            "net_price_per_kwh": round(result["net_price_per_hour"], 6),
-            "gross_price_per_kwh": self.to_gross_price(result["net_price_per_hour"]),
+            "market_price_per_kwh": round(result["market_price_per_hour"], 6),
+            "total_price_per_kwh": self.to_total_price(result["market_price_per_hour"]),
         }

--- a/custom_components/epex_spot/common.py
+++ b/custom_components/epex_spot/common.py
@@ -16,11 +16,11 @@ class Marketprice:
     ):
         self._start_time = start_time
         self._end_time = self._start_time + timedelta(minutes=duration)
-        self._net_price_per_kwh = price
+        self._market_price_per_kwh = price
         self._unit = unit
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(start: {self._start_time.isoformat()}, end: {self._end_time.isoformat()}, marketprice: {self._net_price_per_kwh} {self._unit})"  # noqa: E501
+        return f"{self.__class__.__name__}(start: {self._start_time.isoformat()}, end: {self._end_time.isoformat()}, marketprice: {self._market_price_per_kwh} {self._unit})"  # noqa: E501
 
     @property
     def start_time(self):
@@ -34,8 +34,8 @@ class Marketprice:
         self._end_time = end_time
 
     @property
-    def net_price_per_kwh(self):
-        return self._net_price_per_kwh
+    def market_price_per_kwh(self):
+        return self._market_price_per_kwh
 
 
 def compress_marketdata(data: List[Marketprice], duration: int) -> List[Marketprice]:
@@ -45,7 +45,7 @@ def compress_marketdata(data: List[Marketprice], duration: int) -> List[Marketpr
         if start is None:
             start = entry
             continue
-        is_price_equal = start.net_price_per_kwh == entry.net_price_per_kwh
+        is_price_equal = start.market_price_per_kwh == entry.market_price_per_kwh
         is_continuation = start.end_time == entry.start_time
         max_start_time = start.start_time + timedelta(minutes=duration)
         is_same_interval = entry.start_time < max_start_time
@@ -75,7 +75,7 @@ def average_marketdata(
     for i in range(0, len(data), group_size):
         group = data[i : i + group_size]
 
-        avg_price = round(sum(e._net_price_per_kwh for e in group) / len(group), 5)
+        avg_price = round(sum(e._market_price_per_kwh for e in group) / len(group), 5)
         start = group[0]._start_time
 
         result.append(

--- a/custom_components/epex_spot/const.py
+++ b/custom_components/epex_spot/const.py
@@ -27,7 +27,7 @@ CONF_SOURCE_ENERGYFORECAST = "Energyforecast.de"
 CONF_SOURCE_ENTSOE = "ENTSO-E-Transparency"
 CONF_SOURCE_ENERGYCHARTS = "Energy-Charts.info"
 
-# configuration options for net price calculation
+# configuration options for total price calculation
 CONF_SURCHARGE_PERC = "percentage_surcharge"
 CONF_SURCHARGE_ABS = "absolute_surcharge"
 CONF_TAX = "tax"
@@ -47,8 +47,8 @@ DEFAULT_DURATION = 60
 EMPTY_EXTREME_PRICE_INTERVAL_RESP = {
     "start": None,
     "end": None,
-    "net_price_per_kwh": None,
-    "gross_price_per_kwh": None,
+    "market_price_per_kwh": None,
+    "total_price_per_kwh": None,
 }
 
 UOM_EUR_PER_KWH = "€/kWh"

--- a/custom_components/epex_spot/extreme_price_interval.py
+++ b/custom_components/epex_spot/extreme_price_interval.py
@@ -30,7 +30,7 @@ def _calc_interval_price(marketdata, start_time: datetime, duration: timedelta):
             active_duration_in_this_segment = mp.end_time - start_time
 
         total_price += (
-            mp.net_price_per_kwh
+            mp.market_price_per_kwh
             * active_duration_in_this_segment.total_seconds()
             / SECONDS_PER_HOUR
         )
@@ -97,7 +97,7 @@ def find_extreme_price_interval(marketdata, start_times, duration: timedelta, cm
         "start": dt_util.as_local(interval_start_time),
         "end": dt_util.as_local(interval_start_time + duration),
         "interval_price": interval_price,
-        "net_price_per_hour": round(
+        "market_price_per_hour": round(
             interval_price * SECONDS_PER_HOUR / duration.total_seconds(), 6
         ),
     }

--- a/custom_components/epex_spot/test_awattar.py
+++ b/custom_components/epex_spot/test_awattar.py
@@ -20,7 +20,7 @@ async def main():
             await service.fetch()
             print(f"count = {len(service.marketdata)}")
             for e in service.marketdata:
-                print(f"{e.start_time}: {e.net_price_per_kwh} {UOM_EUR_PER_KWH}")
+                print(f"{e.start_time}: {e.market_price_per_kwh} {UOM_EUR_PER_KWH}")
 
 
 asyncio.run(main())

--- a/custom_components/epex_spot/test_energycharts.py
+++ b/custom_components/epex_spot/test_energycharts.py
@@ -28,7 +28,7 @@ async def main():
             print(f"Fetched entries: {len(md)}")
 
             for e in service.marketdata:
-                print(f"{e.start_time}: {e.net_price_per_kwh} {UOM_EUR_PER_KWH}")
+                print(f"{e.start_time}: {e.market_price_per_kwh} {UOM_EUR_PER_KWH}")
 
 
 if __name__ == "__main__":

--- a/custom_components/epex_spot/test_energyforecast.py
+++ b/custom_components/epex_spot/test_energyforecast.py
@@ -18,7 +18,7 @@ async def main():
         await service.fetch()
         print(f"count = {len(service.marketdata)}")
         for e in service.marketdata:
-            print(f"{e.start_time}: {e.net_price_per_kwh} {UOM_EUR_PER_KWH}")
+            print(f"{e.start_time}: {e.market_price_per_kwh} {UOM_EUR_PER_KWH}")
 
 
 asyncio.run(main())

--- a/custom_components/epex_spot/test_entsoe.py
+++ b/custom_components/epex_spot/test_entsoe.py
@@ -37,7 +37,7 @@ async def main():
             print(f"Fetched entries: {len(md)}")
 
             for e in service.marketdata:
-                print(f"{e.start_time}: {e.net_price_per_kwh} {UOM_EUR_PER_KWH}")
+                print(f"{e.start_time}: {e.market_price_per_kwh} {UOM_EUR_PER_KWH}")
 
 
 if __name__ == "__main__":

--- a/custom_components/epex_spot/test_smard.py
+++ b/custom_components/epex_spot/test_smard.py
@@ -21,7 +21,7 @@ async def main():
             await service.fetch()
             print(f"duration={duration} count = {len(service.marketdata)}")
             for e in service.marketdata:
-                print(f"{e.start_time}: {e.net_price_per_kwh} {UOM_EUR_PER_KWH}")
+                print(f"{e.start_time}: {e.market_price_per_kwh} {UOM_EUR_PER_KWH}")
 
 
 asyncio.run(main())

--- a/custom_components/epex_spot/test_smartenergy.py
+++ b/custom_components/epex_spot/test_smartenergy.py
@@ -20,7 +20,7 @@ async def main():
             await service.fetch()
             print(f"count = {len(service.marketdata)}")
             for e in service.marketdata:
-                print(f"{e.start_time}: {e.net_price_per_kwh} {UOM_EUR_PER_KWH}")
+                print(f"{e.start_time}: {e.market_price_per_kwh} {UOM_EUR_PER_KWH}")
 
 
 asyncio.run(main())

--- a/custom_components/epex_spot/test_tibber.py
+++ b/custom_components/epex_spot/test_tibber.py
@@ -22,7 +22,7 @@ async def main():
             await service.fetch()
             print(f"duration={duration} count = {len(service.marketdata)}")
             for e in service.marketdata:
-                print(f"{e.start_time}: {e.net_price_per_kwh} {UOM_EUR_PER_KWH}")
+                print(f"{e.start_time}: {e.market_price_per_kwh} {UOM_EUR_PER_KWH}")
 
 
 asyncio.run(main())

--- a/custom_components/epex_spot/translations/en.json
+++ b/custom_components/epex_spot/translations/en.json
@@ -18,8 +18,8 @@
         }
       },
       "options": {
-        "title": "Net Price Options",
-        "description": "Configure surcharges and tax to calculate net price per kWh.",
+        "title": "Total Price Options",
+        "description": "Configure surcharges and tax to calculate total price per kWh.",
         "data": {
           "percentage_surcharge": "Percentage Surcharge (%)",
           "absolute_surcharge": "Absolute Surcharge (€/£ per kWh)",
@@ -34,8 +34,8 @@
   "options": {
     "step": {
       "init": {
-        "title": "Net Price Options",
-        "description": "Configure surcharges and tax to calculate net price per kWh.",
+        "title": "Total Price Options",
+        "description": "Configure surcharges and tax to calculate total price per kWh.",
         "data": {
           "duration": "Slot duration",
           "percentage_surcharge": "Percentage Surcharge (%)",


### PR DESCRIPTION
As per https://github.com/mampfes/ha_epex_spot/issues/218 gross and net price sometimes causes confusion. These PR changes the sensor names again s.t. there is hopefully no confusion any more.