### PR TITLE
Add Support for Hofer Grünstrom

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ You can choose between multiple sources:
    No registration or API token is required.
 
 8. Hofer Grünstrom
-   [Hofer Grünstrom](https://www.hofer-grünstrom.at/tarife-zum-geld-sparen#spot) has an open API for accessing market data for Austria. So far no user identifiation is required. (This API is not officially documented, but was discovered by reverse engineering the Hofer Grünstrom website.)
+   [Hofer Grünstrom](https://www.hofer-grünstrom.at/tarife-zum-geld-sparen#spot) has an open API for accessing market data for Austria. So far no user identification is required. (This API is not officially documented, but was discovered by reverse engineering the Hofer Grünstrom website.)
+
+   ⚠️ **Note:** The SSL certificate used by the Hofer Grünstrom API is not trusted publicly. Therefore, when using this source, the integration will ignore SSL certificate verification. This is a potential security risk, so please be aware of this when using this source.
 
 If you like this component, please give it a star on [github](https://github.com/mampfes/hacs_epex_spot).
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ You can choose between multiple sources:
    [Energy-Charts](https://energy-charts.info) provides a publicly accessible API offering real-time electricity market prices for many European bidding zones.  
    No registration or API token is required.
 
+6. Hofer Grünstrom
+   [Hofer Grünstrom](https://www.hofer-grünstrom.at/tarife-zum-geld-sparen#spot) has an open API for accessing market data for Austria. So far no user identifiation is required. (This API is not officially documented, but was discovered by reverse engineering the Hofer Grünstrom website.)
+
 If you like this component, please give it a star on [github](https://github.com/mampfes/hacs_epex_spot).
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -17,29 +17,29 @@ There is a companion integration which simplifies the use of EPEX Spot integrati
 
 You can choose between multiple sources:
 
-1. Awattar  
+1. Awattar
    [Awattar](https://www.awattar.de/services/api) provides a free of charge service for their customers. Market price data is available for Germany and Austria. So far no user identifiation is required.
 
-2. Energyforecast.de  
+2. Energyforecast.de
    [Energyforecast.de](https://www.energyforecast.de/api-docs/index.html) provides services to get market price data forecasts for Germany up to 96 hours into the future. An API token is required.
 
-3. SMARD.de  
+3. SMARD.de
    [SMARD.de](https://www.smard.de) provides a free of charge API to retrieve a lot of information about electricity market including market prices. SMARD.de is serviced by the Bundesnetzagentur, Germany.
 
-4. smartENERGY.at  
+4. smartENERGY.at
    [smartENERGY.at](https://www.smartenergy.at/api-schnittstellen) provides a free of charge service for their customers. Market price data is available for Austria. So far no user identifiation is required.
 
-5. Tibber  
+5. Tibber
    [Tibber](https://developer.tibber.com) is a digital energy supplier that offers an API to access real-time electricity data (prices, consumption, devices, etc.). An API token is required.
 
-6. ENTSO‑E Transparency Platform  
+6. ENTSO‑E Transparency Platform
    [ENTSO‑E](https://transparency.entsoe.eu/) operates a Transparency Platform providing a RESTful API for electricity market data (prices, load forecasts, generation, cross-border flows, etc.). An API token is required ([How to get security token?](https://transparencyplatform.zendesk.com/hc/en-us/articles/12845911031188-How-to-get-security-token)).
 
-7. Energy-Charts.info (Fraunhofer ISE)  
-   [Energy-Charts](https://energy-charts.info) provides a publicly accessible API offering real-time electricity market prices for many European bidding zones.  
+7. Energy-Charts.info (Fraunhofer ISE)
+   [Energy-Charts](https://energy-charts.info) provides a publicly accessible API offering real-time electricity market prices for many European bidding zones.
    No registration or API token is required.
 
-6. Hofer Grünstrom
+8. Hofer Grünstrom
    [Hofer Grünstrom](https://www.hofer-grünstrom.at/tarife-zum-geld-sparen#spot) has an open API for accessing market data for Austria. So far no user identifiation is required. (This API is not officially documented, but was discovered by reverse engineering the Hofer Grünstrom website.)
 
 If you like this component, please give it a star on [github](https://github.com/mampfes/hacs_epex_spot).
@@ -120,7 +120,7 @@ Total Price = ((Market Price * 1.03) + 0.012) * 1.19
 ```
 
 > [!NOTE]
-> smartENERGY.at  
+> smartENERGY.at
 > As of Feb 2024, even though smartENERGY says that the prices reported by the API already include 20% tax (meaning users would configure the sensor to add a static €0.0144 to every price value from the API), [this is incorrect, and the API reports pricing without Tax](https://github.com/mampfes/ha_epex_spot/issues/108#issuecomment-1951423366 "this is incorrect, and the API reports pricing without Tax").
 > To get the actual, current total price [listed by smartENERGY on their website](https://www.smartenergy.at/smartcontrol#:~:text=Aktueller%20Stundenpreis "listed by smartENERGY on their website"), configure:
 > - Absolute surcharge = €0.012

--- a/custom_components/epex_spot/EPEXSpot/HoferGruenstrom/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/HoferGruenstrom/__init__.py
@@ -102,10 +102,6 @@ class HoferGruenstrom:
                 continue
             # extract market data
             for item in data:
-                if not item.get("from") or not item.get("to") or not item.get("price"):
-                    _LOGGER.warning("Skipping item with missing fields: %s", item)
-                    continue
-                # create Marketprice instance
                 marketdata.append(Marketprice(item))
 
         self._marketdata = marketdata

--- a/custom_components/epex_spot/EPEXSpot/HoferGruenstrom/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/HoferGruenstrom/__init__.py
@@ -1,0 +1,126 @@
+"""Hofer Gruenstrom API."""
+
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+import logging
+
+import aiohttp
+
+from ...const import TIMEZONE_HOFER_GRUENSTROM
+from custom_components.epex_spot import const
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _set_tz_on_date(date):
+    """Set timezone on a date object."""
+    timezone = ZoneInfo(TIMEZONE_HOFER_GRUENSTROM)
+
+    if date.tzinfo is None:
+        return date.replace(tzinfo=timezone)
+
+    return date.astimezone(timezone)
+
+
+class Marketprice:
+    """Marketprice class for Hofer Gruenstrom."""
+
+    def __init__(self, data):
+        self._from = datetime.fromisoformat(data["from"])
+        self._to = datetime.fromisoformat(data["to"])
+        # price does not include vat or other taxes, so it is already in the correct format
+        self._price = round(float(data["price"]) / 100, 6)
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(start: {self._from.isoformat()}, "
+            f"end: {self._to.isoformat()}, price: {self._price} {const.CT_PER_KWH})"
+        )
+
+    @property
+    def start_time(self):
+        return _set_tz_on_date(self._from)
+
+    @property
+    def end_time(self):
+        return _set_tz_on_date(self._to)
+
+    @property
+    def price_per_kwh(self):
+        return self._price
+
+
+class HoferGruenstrom:
+    URL = "https://www.xn--hofer-grnstrom-nsb.at/service/energy-manager/spot-prices"
+
+    MARKET_AREAS = ("at",)
+
+    def __init__(self, market_area, session: aiohttp.ClientSession):
+        self._session = session
+        self._market_area = market_area
+        self._duration = 15  # default value, can be overwritten by API response
+        self._marketdata = []
+
+    @property
+    def name(self):
+        return "Hofer Gruenstrom API"
+
+    @property
+    def market_area(self):
+        return self._market_area
+
+    @property
+    def duration(self):
+        return self._duration
+
+    @property
+    def currency(self):
+        return "EUR"
+
+    @property
+    def marketdata(self):
+        return self._marketdata
+
+    async def fetch(self):
+        # get todays and tomorrows date components
+        today = datetime.now()
+        tomorrow = today + timedelta(days=1)
+        dates = [today, tomorrow]
+
+        # fetch data for today and tomorrow
+
+        marketdata = []
+        for date in dates:
+            raw_data = await self._fetch_data_for_date(date)
+            if raw_data is None:
+                continue
+
+            # get the data key from the response
+            data = raw_data.get("data")
+            if not data:
+                _LOGGER.error("No data found in response for %s", date.isoformat())
+                continue
+            # extract market data
+            for item in data:
+                if not item.get("from") or not item.get("to") or not item.get("price"):
+                    _LOGGER.warning("Skipping item with missing fields: %s", item)
+                    continue
+                # create Marketprice instance
+                marketdata.append(Marketprice(item))
+
+        self._marketdata = marketdata
+
+    async def _fetch_data_for_date(self, date):
+        """Fetch data for a specific date."""
+        url = f"{self.URL}?year={date.year}&month={date.month}&day={date.day}"
+        async with self._session.get(url) as response:
+            if response.status != 200:
+                if response.status == 204:
+                    _LOGGER.debug("No data available for %s yet.", date.isoformat())
+                    return None
+                _LOGGER.error(
+                    "Failed to fetch data from Hofer Gruenstrom API: %s",
+                    response.status,
+                )
+                return None
+            return await response.json()

--- a/custom_components/epex_spot/EPEXSpot/HoferGruenstrom/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/HoferGruenstrom/__init__.py
@@ -65,7 +65,7 @@ class HoferGruenstrom:
 
     async def fetch(self):
         # get todays and tomorrows date components
-        today = datetime.now()
+        today = datetime.now(ZoneInfo(TIMEZONE_HOFER_GRUENSTROM))
         tomorrow = today + timedelta(days=1)
         dates = [today, tomorrow]
 
@@ -126,7 +126,10 @@ class HoferGruenstrom:
             return await response.json()
 
     def _get_duration_from_data(self, data):
+        if not data:
+            _LOGGER.error("Empty data received in _get_duration_from_data")
+            raise ValueError("Cannot determine duration from empty data")
         start_date: datetime = datetime.fromisoformat(data[0]["from"])
         end_date: datetime = datetime.fromisoformat(data[0]["to"])
         duration: timedelta = end_date - start_date
-        return int(duration.seconds / 60)
+        return int(duration.total_seconds() / 60)

--- a/custom_components/epex_spot/SourceShell.py
+++ b/custom_components/epex_spot/SourceShell.py
@@ -24,6 +24,7 @@ from custom_components.epex_spot.const import (
     CONF_SOURCE_SMARD_DE,
     CONF_SOURCE_SMARTENERGY,
     CONF_SOURCE_TIBBER,
+    CONF_SOURCE_HOFER_GRUENSTROM,
     CONF_SURCHARGE_ABS,
     CONF_SURCHARGE_PERC,
     CONF_TAX,
@@ -42,6 +43,7 @@ from custom_components.epex_spot.EPEXSpot import (
     smartENERGY,
     ENTSOE,
     EnergyCharts,
+    HoferGruenstrom,
 )
 from .extreme_price_interval import find_extreme_price_interval, get_start_times
 
@@ -101,6 +103,10 @@ class SourceShell:
                 market_area=config_entry.data[CONF_MARKET_AREA],
                 duration=config_entry.options.get(CONF_DURATION, DEFAULT_DURATION),
                 session=session,
+            )
+        elif config_entry.data[CONF_SOURCE] == CONF_SOURCE_HOFER_GRUENSTROM:
+            self._source = HoferGruenstrom.HoferGruenstrom(
+                market_area=config_entry.data[CONF_MARKET_AREA], session=session
             )
         else:
             raise ValueError(f"Unsupported source: {config_entry.data[CONF_SOURCE]}")

--- a/custom_components/epex_spot/SourceShell.py
+++ b/custom_components/epex_spot/SourceShell.py
@@ -106,7 +106,9 @@ class SourceShell:
             )
         elif config_entry.data[CONF_SOURCE] == CONF_SOURCE_HOFER_GRUENSTROM:
             self._source = HoferGruenstrom.HoferGruenstrom(
-                market_area=config_entry.data[CONF_MARKET_AREA], session=session
+                market_area=config_entry.data[CONF_MARKET_AREA],
+                duration=config_entry.options.get(CONF_DURATION, DEFAULT_DURATION),
+                session=session,
             )
         else:
             raise ValueError(f"Unsupported source: {config_entry.data[CONF_SOURCE]}")

--- a/custom_components/epex_spot/config_flow.py
+++ b/custom_components/epex_spot/config_flow.py
@@ -19,6 +19,7 @@ from .const import (
     CONF_SOURCE_TIBBER,
     CONF_SOURCE_ENERGYFORECAST,
     CONF_SOURCE_ENERGYCHARTS,
+    CONF_SOURCE_HOFER_GRUENSTROM,
     CONF_SURCHARGE_ABS,
     CONF_SURCHARGE_PERC,
     CONF_TAX,
@@ -39,6 +40,7 @@ from .EPEXSpot import (
     Energyforecast,
     ENTSOE,
     EnergyCharts,
+	HoferGruenstrom
 )
 
 CONF_SOURCE_LIST = (
@@ -49,6 +51,7 @@ CONF_SOURCE_LIST = (
     CONF_SOURCE_TIBBER,
     CONF_SOURCE_ENERGYFORECAST,
     CONF_SOURCE_ENERGYCHARTS,
+    CONF_SOURCE_HOFER_GRUENSTROM,
 )
 
 
@@ -234,5 +237,6 @@ def getParametersForSource(
             EnergyCharts.EnergyCharts.SUPPORTED_DURATIONS,
             False,
         )
+    // TODO: Re-add Hofer Gruenstrom
 
     return ([], [], False)

--- a/custom_components/epex_spot/config_flow.py
+++ b/custom_components/epex_spot/config_flow.py
@@ -107,7 +107,18 @@ class EpexSpotConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore
             )
         )
 
-        return self.async_show_form(step_id="market_area", data_schema=data_schema)
+        # Add warning for HoferGruenstrom about disabled SSL
+        description_placeholders = {}
+        if self._source_name == CONF_SOURCE_HOFER_GRUENSTROM:
+            description_placeholders = {
+                "ssl_warning": "Warning: SSL certificate verification is disabled for this source."
+            }
+
+        return self.async_show_form(
+            step_id="market_area",
+            data_schema=data_schema,
+            description_placeholders=description_placeholders,
+        )
 
     async def async_step_market_area(self, user_input=None):
         if user_input is not None:

--- a/custom_components/epex_spot/config_flow.py
+++ b/custom_components/epex_spot/config_flow.py
@@ -40,7 +40,7 @@ from .EPEXSpot import (
     Energyforecast,
     ENTSOE,
     EnergyCharts,
-	HoferGruenstrom,
+    HoferGruenstrom,
 )
 
 CONF_SOURCE_LIST = (

--- a/custom_components/epex_spot/config_flow.py
+++ b/custom_components/epex_spot/config_flow.py
@@ -40,7 +40,7 @@ from .EPEXSpot import (
     Energyforecast,
     ENTSOE,
     EnergyCharts,
-	HoferGruenstrom
+	HoferGruenstrom,
 )
 
 CONF_SOURCE_LIST = (
@@ -237,6 +237,11 @@ def getParametersForSource(
             EnergyCharts.EnergyCharts.SUPPORTED_DURATIONS,
             False,
         )
-    // TODO: Re-add Hofer Gruenstrom
+    if source_name == CONF_SOURCE_HOFER_GRUENSTROM:
+        return (
+            HoferGruenstrom.HoferGruenstrom.MARKET_AREAS,
+            HoferGruenstrom.HoferGruenstrom.SUPPORTED_DURATIONS,
+            False,
+        )
 
     return ([], [], False)

--- a/custom_components/epex_spot/const.py
+++ b/custom_components/epex_spot/const.py
@@ -26,6 +26,7 @@ CONF_SOURCE_TIBBER = "Tibber"
 CONF_SOURCE_ENERGYFORECAST = "Energyforecast.de"
 CONF_SOURCE_ENTSOE = "ENTSO-E-Transparency"
 CONF_SOURCE_ENERGYCHARTS = "Energy-Charts.info"
+CONF_SOURCE_HOFER_GRUENSTROM = "Hofer Gruenstrom"
 
 # configuration options for total price calculation
 CONF_SURCHARGE_PERC = "percentage_surcharge"
@@ -50,6 +51,8 @@ EMPTY_EXTREME_PRICE_INTERVAL_RESP = {
     "market_price_per_kwh": None,
     "total_price_per_kwh": None,
 }
+
+TIMEZONE_HOFER_GRUENSTROM = "Europe/Vienna"
 
 UOM_EUR_PER_KWH = "€/kWh"
 UOM_MWH = "MWh"

--- a/custom_components/epex_spot/test_hofer_gruenstrom.py
+++ b/custom_components/epex_spot/test_hofer_gruenstrom.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+import asyncio
+
+import aiohttp
+
+from .const import UOM_EUR_PER_KWH
+from .EPEXSpot import HoferGruenstrom
+
+
+async def main():
+    async with aiohttp.ClientSession() as session:
+        service = HoferGruenstrom.HoferGruenstrom(market_area="at", session=session)
+
+        await service.fetch()
+        print(f"count = {len(service.marketdata)}")
+        for e in service.marketdata:
+            print(f"{e.start_time}-{e.end_time}: {e.price_per_kwh} {UOM_EUR_PER_KWH}")
+
+
+asyncio.run(main())

--- a/custom_components/epex_spot/test_hofer_gruenstrom.py
+++ b/custom_components/epex_spot/test_hofer_gruenstrom.py
@@ -10,7 +10,7 @@ from .EPEXSpot import HoferGruenstrom
 
 async def main():
     async with aiohttp.ClientSession() as session:
-        service = HoferGruenstrom.HoferGruenstrom(market_area="at", session=session)
+        service = HoferGruenstrom.HoferGruenstrom(market_area="at", session=session, duration=15)
 
         await service.fetch()
         print(f"count = {len(service.marketdata)}")

--- a/custom_components/epex_spot/test_hofer_gruenstrom.py
+++ b/custom_components/epex_spot/test_hofer_gruenstrom.py
@@ -15,7 +15,7 @@ async def main():
         await service.fetch()
         print(f"count = {len(service.marketdata)}")
         for e in service.marketdata:
-            print(f"{e.start_time}-{e.end_time}: {e.price_per_kwh} {UOM_EUR_PER_KWH}")
+            print(f"{e.start_time}-{e.end_time}: {e.market_price_per_kwh} {UOM_EUR_PER_KWH}")
 
 
 asyncio.run(main())

--- a/custom_components/epex_spot/translations/en.json
+++ b/custom_components/epex_spot/translations/en.json
@@ -15,7 +15,8 @@
           "market_area": "Select market area",
           "duration": "Slot duration",
           "token": "API Token"
-        }
+        },
+        "description": "{ssl_warning}"
       },
       "options": {
         "title": "Total Price Options",


### PR DESCRIPTION
> This is a re-open of #214 with adaptions in place for the latest 4.0.0 updates.

This PR adds the unofficial Hofer Grünstrom API which is publicly available on [this website](https://www.xn--hofer-grnstrom-nsb.at/tarife-zum-geld-sparen#spot). There is one minor inconvenience though: since they only use the API internally the SSL certificate is not publicly trusted and the `get` call needs to be set to `self._session.get(url, ssl=False)` in order to work.

The API provides data for each day in 15 minutes intervals, and has data ready for the upcoming day at around 14:00.

For more information have a look at the corresponding issue: https://github.com/mampfes/ha_epex_spot/issues/213