### PR TITLE
fix empty durations validation error in options flow

### DIFF
--- a/custom_components/epex_spot/config_flow.py
+++ b/custom_components/epex_spot/config_flow.py
@@ -168,6 +168,10 @@ class EpexSpotOptionsFlow(OptionsFlowWithReload):
             self.config_entry.data.get(CONF_SOURCE)
         )
 
+        # Fallback to common durations if source is not recognized
+        if not durations:
+            durations = [15, 60]
+
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(


### PR DESCRIPTION
When opening the options dialog, if the stored source name doesn't match any known source (e.g. after migration or data issues), `getParametersForSource()` returns empty lists. This causes `vol.In([])` to fail with "value must be one of []".

Added a fallback to common durations (15, 60 min) when the source can't be determined.

Should fix: https://github.com/mampfes/ha_epex_spot/issues/270 