### PR TITLE
energyforecast: add support for missing market areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can choose between multiple sources:
    [Awattar](https://www.awattar.de/services/api) provides a free of charge service for their customers. Market price data is available for Germany and Austria. So far no user identifiation is required.
 
 2. Energyforecast.de
-   [Energyforecast.de](https://www.energyforecast.de/api-docs/index.html) provides services to get market price data forecasts for Germany up to 96 hours into the future. An API token is required.
+   [Energyforecast.de](https://www.energyforecast.de/api-docs/index.html) provides services to get market price data forecasts for multiple market areas (AT, BE, DE-LU, DK1, DK2, FR, NL, PL) up to 96 hours into the future. An API token is required.
 
 3. SMARD.de
    [SMARD.de](https://www.smard.de) provides a free of charge API to retrieve a lot of information about electricity market including market prices. SMARD.de is serviced by the Bundesnetzagentur, Germany.

--- a/custom_components/epex_spot/EPEXSpot/Energyforecast/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/Energyforecast/__init__.py
@@ -38,13 +38,7 @@ class Marketprice:
 class Energyforecast:
     URL = "https://www.energyforecast.de/api/v1/predictions/prices_for_ha"
 
-    MARKET_AREAS = {
-    "de": "DE-LU",
-    "be": "BE",
-    "nl": "NL",
-    "fr": "FR",
-    "at": "AT",
-}
+    MARKET_AREAS = ("AT", "BE", "DE-LU", "DK1", "DK2", "FR", "NL", "PL")
     SUPPORTED_DURATIONS = (15, 60)
 
     def __init__(
@@ -93,7 +87,7 @@ class Energyforecast:
                 "fixed_cost_cent": 0,
                 "vat": 0,
                 "resolution": self._resolution,
-                "market_zone": self.MARKET_AREAS[self._market_area],
+                "market_zone": self._market_area,
             },
         ) as resp:
             resp.raise_for_status()

--- a/custom_components/epex_spot/test_energyforecast.py
+++ b/custom_components/epex_spot/test_energyforecast.py
@@ -11,14 +11,19 @@ DEMO_TOKEN = "demo_token"  # The "demo_token" token only provides up to 24 hours
 
 async def main():
     async with aiohttp.ClientSession() as session:
-        service = Energyforecast.Energyforecast(
-            market_area="DE-LU", token=DEMO_TOKEN, session=session
-        )
+        durations = [15, 60]
 
-        await service.fetch()
-        print(f"count = {len(service.marketdata)}")
-        for e in service.marketdata:
-            print(f"{e.start_time}: {e.market_price_per_kwh} {UOM_EUR_PER_KWH}")
+        for duration in durations:
+            print(f"\n=== Testing Energyforecast: {duration} minutes ===")
+
+            service = Energyforecast.Energyforecast(
+                market_area="DE-LU", duration=duration, token=DEMO_TOKEN, session=session
+            )
+
+            await service.fetch()
+            print(f"count = {len(service.marketdata)}")
+            for e in service.marketdata:
+                print(f"{e.start_time}: {e.market_price_per_kwh} {UOM_EUR_PER_KWH}")
 
 
 asyncio.run(main())


### PR DESCRIPTION
Not sure why but some market areas that are supported by my service energyforecast.de where missing. I added those: DK1, DK2, PL. Also I updated the Readme file and the test file to test both supported durations 15 and 60 min.