### PR TITLE
Add NextEnergy provider (Dutch EPEX Day Ahead NL)

### DIFF
--- a/custom_components/epex_spot/EPEXSpot/NextEnergy/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/NextEnergy/__init__.py
@@ -36,6 +36,7 @@ class NextEnergy:
         self._market_area = market_area
         self._duration = duration
         self._marketdata = []
+        self._os_visitor = None  # cached: server only sends this once (100-yr expiry)
 
     @property
     def name(self) -> str:
@@ -82,14 +83,16 @@ class NextEnergy:
             resp.raise_for_status()
             data = await resp.json()
             version_token = data["versionToken"]
-            # The nr2Users cookie carries the anonymous CSRF token for OutSystems.
-            # uid=0 and unm= indicate an anonymous user.
+            # osVisit is refreshed every 30 min; osVisitor is long-lived (100-yr
+            # expiry) so the server only sets it on the very first request.
+            if "osVisitor" in resp.cookies:
+                self._os_visitor = resp.cookies["osVisitor"].value
             nr2_value = urllib.parse.quote(
                 f"crf={CSRF_TOKEN};uid=0;unm=", safe=""
             )
             cookies = {
                 "osVisit": resp.cookies["osVisit"].value,
-                "osVisitor": resp.cookies["osVisitor"].value,
+                "osVisitor": self._os_visitor,
                 "nr2Users": nr2_value,
             }
             return version_token, cookies

--- a/custom_components/epex_spot/EPEXSpot/NextEnergy/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/NextEnergy/__init__.py
@@ -1,0 +1,195 @@
+"""NextEnergy API provider for Dutch electricity market prices."""
+
+from datetime import datetime, timedelta, date as date_type
+import logging
+import re
+from typing import List
+import urllib.parse
+from zoneinfo import ZoneInfo
+
+import aiohttp
+
+from homeassistant.util import dt as dt_util
+
+from ...common import Marketprice
+from ...const import UOM_EUR_PER_KWH
+
+_LOGGER = logging.getLogger(__name__)
+
+TZ_AMSTERDAM = ZoneInfo("Europe/Amsterdam")
+
+URL_VERSION = "https://mijn.nextenergy.nl/Website_CW/moduleservices/moduleversioninfo"
+URL_PRICES = "https://mijn.nextenergy.nl/Website_CW/screenservices/Website_CW/Blocks/WB_EnergyPrices/DataActionGetDataPoints"
+
+# The anonymous CSRF token is a constant baked into the OutSystems application JS.
+# It is the fallback CSRF token used for unauthenticated (anonymous) sessions.
+CSRF_TOKEN = "T6C+9iB49TLra4jEsMeSckDMNhQ="
+API_VERSION = "KKzGGxaqgJLBcYSoN9w5oA"
+
+
+class NextEnergy:
+    MARKET_AREAS = ("nl",)
+    SUPPORTED_DURATIONS = (60,)
+
+    def __init__(self, market_area: str, duration: int, session: aiohttp.ClientSession):
+        self._session = session
+        self._market_area = market_area
+        self._duration = duration
+        self._marketdata = []
+
+    @property
+    def name(self) -> str:
+        return "NextEnergy"
+
+    @property
+    def market_area(self) -> str:
+        return self._market_area
+
+    @property
+    def duration(self) -> int:
+        return self._duration
+
+    @property
+    def currency(self) -> str:
+        return "EUR"
+
+    @property
+    def marketdata(self) -> List[Marketprice]:
+        return self._marketdata
+
+    async def fetch(self):
+        version_token, cookies = await self._init_session()
+
+        today = dt_util.now().astimezone(TZ_AMSTERDAM).date()
+        tomorrow = today + timedelta(days=1)
+
+        marketdata = []
+        for fetch_date in (today, tomorrow):
+            data = await self._fetch_prices(fetch_date, version_token, cookies)
+            marketdata.extend(self._parse_prices(data, fetch_date))
+
+        self._marketdata = sorted(marketdata, key=lambda e: e.start_time)
+
+    async def _init_session(self):
+        """Fetch a fresh session from OutSystems and return (version_token, cookies)."""
+        async with self._session.get(
+            URL_VERSION,
+            headers={
+                "Accept": "application/json",
+                "Referer": "https://mijn.nextenergy.nl/Website_CW/MarketPrices",
+            },
+        ) as resp:
+            resp.raise_for_status()
+            data = await resp.json()
+            version_token = data["versionToken"]
+            # The nr2Users cookie carries the anonymous CSRF token for OutSystems.
+            # uid=0 and unm= indicate an anonymous user.
+            nr2_value = urllib.parse.quote(
+                f"crf={CSRF_TOKEN};uid=0;unm=", safe=""
+            )
+            cookies = {
+                "osVisit": resp.cookies["osVisit"].value,
+                "osVisitor": resp.cookies["osVisitor"].value,
+                "nr2Users": nr2_value,
+            }
+            return version_token, cookies
+
+    async def _fetch_prices(self, fetch_date: date_type, version_token: str, cookies: dict) -> list:
+        """Fetch hourly prices for a given date."""
+        date_str = fetch_date.strftime("%Y-%m-%d")
+        payload = {
+            "versionInfo": {
+                "moduleVersion": version_token,
+                "apiVersion": API_VERSION,
+            },
+            "viewName": "MainFlow.MarketPrices",
+            "screenData": {
+                "variables": {
+                    "Graphsize": 235,
+                    "IsOpenPopup": False,
+                    "HighchartsJSON": "",
+                    "DistributionId": 3,
+                    "IsDesktop": False,
+                    "IsTablet": False,
+                    "IsLoading": True,
+                    "NE_StartDate": "2022-07-01",
+                    "Filter": {
+                        "PriceIncludingVAT": False,
+                        "PriceDate": date_str,
+                        "CostsLevel": "MarketPrice",
+                        "CurrentHour": 0,
+                    },
+                }
+            },
+        }
+        # Build cookie string manually to preserve nr2Users URL-encoding
+        cookie_str = "; ".join(f"{k}={v}" for k, v in cookies.items())
+        async with self._session.post(
+            URL_PRICES,
+            json=payload,
+            headers={
+                "Accept": "application/json",
+                "Referer": "https://mijn.nextenergy.nl/Website_CW/MarketPrices",
+                "Origin": "https://mijn.nextenergy.nl",
+                "X-CSRFToken": CSRF_TOKEN,
+                "Cookie": cookie_str,
+            },
+        ) as resp:
+            resp.raise_for_status()
+            result = await resp.json()
+
+        if result.get("exception"):
+            raise ValueError(
+                f"NextEnergy API error: {result['exception'].get('message')}"
+            )
+
+        version_info = result.get("versionInfo", {})
+        if version_info.get("hasApiVersionChanged"):
+            _LOGGER.warning(
+                "NextEnergy API version has changed. "
+                "The integration may need to be updated."
+            )
+
+        return result["data"]["DataPoints"]["List"]
+
+    def _parse_prices(self, data_points: list, fetch_date: date_type) -> List[Marketprice]:
+        """Parse API response into Marketprice objects."""
+        entries = []
+        for point in data_points:
+            tooltip = point.get("Tooltip", "")
+            # Tooltip format: "Nh €X.XX" where N is the local hour (0-23)
+            match = re.match(r"^(\d+)h", tooltip)
+            if not match:
+                _LOGGER.warning("Unexpected tooltip format: %s", tooltip)
+                continue
+
+            hour = int(match.group(1))
+            price_str = point.get("Value", "")
+            if not price_str:
+                continue
+
+            try:
+                price = float(price_str)
+            except ValueError:
+                _LOGGER.warning("Could not parse price value: %s", price_str)
+                continue
+
+            start_time = datetime(
+                fetch_date.year,
+                fetch_date.month,
+                fetch_date.day,
+                hour,
+                0,
+                0,
+                tzinfo=TZ_AMSTERDAM,
+            )
+            entries.append(
+                Marketprice(
+                    start_time=start_time,
+                    duration=60,
+                    price=price,
+                    unit=UOM_EUR_PER_KWH,
+                )
+            )
+
+        return entries

--- a/custom_components/epex_spot/SourceShell.py
+++ b/custom_components/epex_spot/SourceShell.py
@@ -25,6 +25,7 @@ from custom_components.epex_spot.const import (
     CONF_SOURCE_SMARTENERGY,
     CONF_SOURCE_TIBBER,
     CONF_SOURCE_HOFER_GRUENSTROM,
+    CONF_SOURCE_NEXTENERGY,
     CONF_SURCHARGE_ABS,
     CONF_SURCHARGE_PERC,
     CONF_TAX,
@@ -44,6 +45,7 @@ from custom_components.epex_spot.EPEXSpot import (
     ENTSOE,
     EnergyCharts,
     HoferGruenstrom,
+    NextEnergy,
 )
 from .extreme_price_interval import find_extreme_price_interval, get_start_times
 
@@ -106,6 +108,12 @@ class SourceShell:
             )
         elif config_entry.data[CONF_SOURCE] == CONF_SOURCE_HOFER_GRUENSTROM:
             self._source = HoferGruenstrom.HoferGruenstrom(
+                market_area=config_entry.data[CONF_MARKET_AREA],
+                duration=config_entry.options.get(CONF_DURATION, DEFAULT_DURATION),
+                session=session,
+            )
+        elif config_entry.data[CONF_SOURCE] == CONF_SOURCE_NEXTENERGY:
+            self._source = NextEnergy.NextEnergy(
                 market_area=config_entry.data[CONF_MARKET_AREA],
                 duration=config_entry.options.get(CONF_DURATION, DEFAULT_DURATION),
                 session=session,

--- a/custom_components/epex_spot/config_flow.py
+++ b/custom_components/epex_spot/config_flow.py
@@ -111,11 +111,9 @@ class EpexSpotConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore
         )
 
         # Add warning for HoferGruenstrom about disabled SSL
-        description_placeholders = {}
+        description_placeholders = {"ssl_warning": ""}
         if self._source_name == CONF_SOURCE_HOFER_GRUENSTROM:
-            description_placeholders = {
-                "ssl_warning": "Warning: SSL certificate verification is disabled for this source."
-            }
+            description_placeholders["ssl_warning"] = "Warning: SSL certificate verification is disabled for this source."
 
         return self.async_show_form(
             step_id="market_area",

--- a/custom_components/epex_spot/config_flow.py
+++ b/custom_components/epex_spot/config_flow.py
@@ -20,6 +20,7 @@ from .const import (
     CONF_SOURCE_ENERGYFORECAST,
     CONF_SOURCE_ENERGYCHARTS,
     CONF_SOURCE_HOFER_GRUENSTROM,
+    CONF_SOURCE_NEXTENERGY,
     CONF_SURCHARGE_ABS,
     CONF_SURCHARGE_PERC,
     CONF_TAX,
@@ -41,6 +42,7 @@ from .EPEXSpot import (
     ENTSOE,
     EnergyCharts,
     HoferGruenstrom,
+    NextEnergy,
 )
 
 CONF_SOURCE_LIST = (
@@ -52,6 +54,7 @@ CONF_SOURCE_LIST = (
     CONF_SOURCE_ENERGYFORECAST,
     CONF_SOURCE_ENERGYCHARTS,
     CONF_SOURCE_HOFER_GRUENSTROM,
+    CONF_SOURCE_NEXTENERGY,
 )
 
 
@@ -252,6 +255,12 @@ def getParametersForSource(
         return (
             HoferGruenstrom.HoferGruenstrom.MARKET_AREAS,
             HoferGruenstrom.HoferGruenstrom.SUPPORTED_DURATIONS,
+            False,
+        )
+    if source_name == CONF_SOURCE_NEXTENERGY:
+        return (
+            NextEnergy.NextEnergy.MARKET_AREAS,
+            NextEnergy.NextEnergy.SUPPORTED_DURATIONS,
             False,
         )
 

--- a/custom_components/epex_spot/const.py
+++ b/custom_components/epex_spot/const.py
@@ -27,6 +27,7 @@ CONF_SOURCE_ENERGYFORECAST = "Energyforecast.de"
 CONF_SOURCE_ENTSOE = "ENTSO-E-Transparency"
 CONF_SOURCE_ENERGYCHARTS = "Energy-Charts.info"
 CONF_SOURCE_HOFER_GRUENSTROM = "Hofer Gruenstrom"
+CONF_SOURCE_NEXTENERGY = "NextEnergy"
 
 # configuration options for total price calculation
 CONF_SURCHARGE_PERC = "percentage_surcharge"

--- a/custom_components/epex_spot/test_nextenergy.py
+++ b/custom_components/epex_spot/test_nextenergy.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import aiohttp
+import asyncio
+
+from .EPEXSpot import NextEnergy
+from .const import UOM_EUR_PER_KWH
+
+
+async def main():
+    async with aiohttp.ClientSession() as session:
+        service = NextEnergy.NextEnergy(
+            market_area="nl", session=session, duration=60
+        )
+        print("Market areas:", service.MARKET_AREAS)
+
+        await service.fetch()
+        print(f"count = {len(service.marketdata)}")
+        for e in service.marketdata:
+            print(f"{e.start_time}: {e.market_price_per_kwh} {UOM_EUR_PER_KWH}")
+
+
+asyncio.run(main())


### PR DESCRIPTION
## Summary

- Adds **NextEnergy** as a new data source for Dutch electricity market prices
- Fetches hourly EPEX Day Ahead NL prices (beursprijs, excl. BTW) for today and tomorrow
- Netherlands only (`nl`), 60-minute resolution, no API token required
- Also fixes a pre-existing `ssl_warning` placeholder error that surfaces in newer HA versions when opening the config flow for any non-HoferGruenstrom source

## How it works

NextEnergy's public price chart (embedded on their website as an iframe) is served by an OutSystems application at `mijn.nextenergy.nl`. The provider:

1. Calls `moduleservices/moduleversioninfo` to obtain a fresh session cookie and module version token
2. POSTs to the `WB_EnergyPrices/DataActionGetDataPoints` screen service with `CostsLevel: "MarketPrice"` and `PriceIncludingVAT: false`, which returns the raw EPEX beursprijs (excl. BTW) — consistent with other providers in this integration
3. Parses the 24 hourly data points for today and tomorrow, with times anchored to `Europe/Amsterdam` timezone

The anonymous CSRF token (`T6C+9iB49TLra4jEsMeSckDMNhQ=`) is a constant baked into the public OutSystems JS bundle and used for unauthenticated sessions.

## Test plan

- [ ] Add integration → EPEX Spot → source: NextEnergy → market area: `nl`
- [ ] Verify Market Price sensor shows hourly EPEX NL prices
- [ ] Verify 48 data points are available (today + tomorrow after ~13:00 CET)
- [ ] Verify Total Price sensor responds correctly to surcharge/tax configuration
- [ ] Verify no errors after the first hourly refresh (osVisitor cookie caching)

🤖 Generated with [Claude Code](https://claude.com/claude-code)