### PR TITLE
Add custom price templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,54 @@ In case you would like to install manually:
 
    [![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start?domain=epex_spot)
 
+
+## Advanced Price Templates
+
+> [!IMPORTANT]
+> **Overriding Default Calculations:** When you provide a custom template for the import price, the integration's built-in total price calculation (including `Surcharge`, `Tax`, etc. configured in the main options) is **completely bypassed** for that custom sensor. Your template must handle all corporate fees, taxes, and VAT manually.
+
+The integration allows you to specify custom templates for **Import** and **Export** prices directly in the integration's Options flow. This is useful for dynamic energy contracts where pricing includes corporate margins, taxes, or time-of-day bonuses.
+
+The templates have access to the following variables:
+* `market_price`: The raw EPEX spot market price per kWh (float).
+* `now()`: A localized Home Assistant `datetime` object representing the specific hour block being evaluated. This allows accurate future forecasts (e.g., in ApexCharts or the Energy Dashboard) based on time-of-day logic.
+
+### Example: NextEnergie (Netherlands)
+
+Here is a comprehensive real-world configuration example for the Dutch energy provider **NextEnergie**.
+
+#### 1. Import Price Template
+The import price consists of the raw market price plus 21% VAT, a fixed purchasing fee (`€0.0219` incl. VAT), and a energy tax specification that automatically applies from January 1st, 2027 onwards.
+
+```jinja2
+{% set import_base = (market_price * 1.21) + 0.0219 %}
+
+{# Energy tax applies from January 1st, 2027 onwards #}
+{% if now().strftime('%Y-%m-%d') >= '2027-01-01' %}
+  {# Replace 0.1234 with the actual government energy tax rate including VAT #}
+  {% set energy_tax = 0.1234 %}
+{% else %}
+  {% set energy_tax = 0.0 %}
+{% endif %}
+
+{{ import_base + energy_tax }}
+```
+
+#### 2. Export Price Template
+The export price consists of the raw market price plus 21% VAT and a fixed export fee (`€0.0000` incl. VAT). Additionally, a Solar Bonus of +50% is added during daytime hours (between 06:00 and 22:00), provided that the base export price is positive.
+
+```jinja2
+{% set export_base = (market_price * 1.21) + 0.0000 %}
+
+{# Solar Bonus: +50% return during daytime hours if the price is positive #}
+{% if 6 <= now().hour < 22 and export_base > 0 %}
+  {{ export_base * 1.50 }}
+{% else %}
+  {{ export_base }}
+{% endif %}
+```
+
+
 ## Sensors
 
 This integration provides the following sensors:

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ In case you would like to install manually:
 
 ## Advanced Price Templates
 
-> [!IMPORTANT]
-> **Overriding Default Calculations:** When you provide a custom template for the import price, the integration's built-in total price calculation (including `Surcharge`, `Tax`, etc. configured in the main options) is **completely bypassed** for that custom sensor. Your template must handle all corporate fees, taxes, and VAT manually.
+> [!NOTE]
+> **Interval Service Behavior:** When using custom price templates, the `find_extreme_price_interval` service will automatically use your evaluated import price template as the base price. However, the integration's built-in `Total Price` calculations (such as fixed surcharges or tax percentages configured in the main options) will **still be applied** on top of it within the service calculation.
 
 The integration allows you to specify custom templates for **Import** and **Export** prices directly in the integration's Options flow. This is useful for dynamic energy contracts where pricing includes corporate margins, taxes, or time-of-day bonuses.
 

--- a/README.md
+++ b/README.md
@@ -71,60 +71,29 @@ In case you would like to install manually:
 > [!NOTE]
 > **Interval Service Behavior:** When using custom price templates, the `find_extreme_price_interval` service will automatically use your evaluated import price template as the base price. However, the integration's built-in `Total Price` calculations (such as fixed surcharges or tax percentages configured in the main options) will **still be applied** on top of it within the service calculation.
 
-The integration allows you to specify custom templates for **Import** and **Export** prices directly in the integration's Options flow. This is useful for dynamic energy contracts where pricing includes corporate margins, taxes, or time-of-day bonuses.
+The integration allows you to specify templates for **Import** and **Export** prices directly in the integration's Options flow. This is extremely useful for dynamic energy contracts where pricing includes corporate margins, taxes, time-of-day bonuses, or complex national regulations (such as §14a EnWG in Germany or SNAP in Austria).
 
-The templates have access to the following variables:
-* `market_price`: The raw EPEX spot market price per kWh (float).
-* `now()`: A localized Home Assistant `datetime` object representing the specific hour block being evaluated. This allows accurate future forecasts (e.g., in ApexCharts or the Energy Dashboard) based on time-of-day logic.
+### Real-World Examples & Country Configurations
 
-### Example: NextEnergie (Netherlands)
+We maintain a dedicated guide with fully commented, production-ready templates for various countries and energy providers.
 
-Here is a comprehensive real-world configuration example for the Dutch energy provider **NextEnergie**.
-
-#### 1. Import Price Template
-The import price consists of the raw market price plus 21% VAT, a fixed purchasing fee (`€0.0219` incl. VAT), and a energy tax specification that automatically applies from January 1st, 2027 onwards.
-
-```jinja2
-{% set import_base = (market_price * 1.21) + 0.0219 %}
-
-{# Energy tax applies from January 1st, 2027 onwards #}
-{% if now().strftime('%Y-%m-%d') >= '2027-01-01' %}
-  {# Replace 0.1234 with the actual government energy tax rate including VAT #}
-  {% set energy_tax = 0.1234 %}
-{% else %}
-  {% set energy_tax = 0.0 %}
-{% endif %}
-
-{{ import_base + energy_tax }}
-```
-
-#### 2. Export Price Template
-The export price consists of the raw market price plus 21% VAT and a fixed export fee (`€0.0000` incl. VAT). Additionally, a Solar Bonus of +50% is added during daytime hours (between 06:00 and 22:00), provided that the base export price is positive.
-
-```jinja2
-{% set export_base = (market_price * 1.21) + 0.0000 %}
-
-{# Solar Bonus: +50% return during daytime hours if the price is positive #}
-{% if 6 <= now().hour < 22 and export_base > 0 %}
-  {{ export_base * 1.50 }}
-{% else %}
-  {{ export_base }}
-{% endif %}
-```
+👉 **[View Advanced Price Templates Guide (docs/templates.md)](docs/templates.md)**
 
 
 ## Sensors
 
 This integration provides the following sensors:
 
-1. Total price
-2. Market price
-3. Average market price during the day
-4. Median market price during the day
-5. Lowest market price during the day
-6. Highest market price during the day
-7. Current market price quantile during the day
-8. Rank of the current market price during the day
+1. [Total price](#1-total-price-sensor)
+2. [Market price](#2-market-price-sensor)
+3. [Average market price during the day](#3-average-market-price-sensor)
+4. [Median market price during the day](#4-median-market-price-sensor)
+5. [Lowest market price during the day](#5-lowest-market-price-sensor)
+6. [Highest market price during the day](#6-highest-market-price-sensor)
+7. [Current market price quantile during the day](#7-quantile-sensor)
+8. [Rank of the current market price during the day](#8-rank-sensor)
+9. [Import Price](#9-import-price-sensor)
+10. [Export Price](#10-export-price-sensor)
 
 NOTE: For GB data, the prices will be shown in GBP instead of EUR. The sensor attribute names are adjusted accordingly.
 
@@ -250,6 +219,18 @@ Examples:
 - The sensor reports 0 if the current market price is the lowest during the day. There is no lower market price during the day.
 - The sensor reports 23 if the current market price is the highest during the day (if the market price will be updated hourly). There are 23 hours which are cheaper than the current hour market price.
 - The sensor reports 1 if the current market price is the 2nd cheapest during the day. There is 1 one which is cheaper than the current hour market price.
+
+### 9. Import Price Sensor
+
+The sensor value reports the calculated import price (your electricity consumption price) in €/£/kWh based on your `Import price template` configured in the integration's options.
+
+⚠️ **Note:** This sensor is only available and visible if a `Import price template` has been explicitly configured in the integration settings.
+
+### 10. Export Price Sensor
+
+The sensor value reports the calculated export price (your solar feed-in compensation) in €/£/kWh based on your `Export price template` configured in the integration's options.
+
+⚠️ **Note:** This sensor is only available and visible if a `Export price template` has been explicitly configured in the integration settings.
 
 ## Service Calls
 

--- a/custom_components/epex_spot/SourceShell.py
+++ b/custom_components/epex_spot/SourceShell.py
@@ -54,7 +54,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class SourceShell:
-    def __init__(self, config_entry: ConfigEntry, session: aiohttp.ClientSession):
+    def __init__(self, hass, config_entry: ConfigEntry, session: aiohttp.ClientSession):
+        self._hass = hass
         self._config_entry = config_entry
         self._marketdata_now = None
         self._sorted_marketdata_today = []
@@ -206,14 +207,14 @@ class SourceShell:
 
         return round(total_price, 6)
         
-    def _render_custom_template(self, hass, template_str: str, market_price: float, dt_value) -> float:
+    def _render_custom_template(self, template_str: str, market_price: float, dt_value) -> float:
         """Helper to render a custom Jinja2 template with price and datetime context."""
         if not template_str or template_str.strip() == "":
             return market_price
 
         try:
             # Create a Home Assistant Template object
-            compiled_template = template_helper.Template(template_str, hass)
+            compiled_template = template_helper.Template(template_str, self._hass)
             
             # Context variables available to the end-user
             variables = {
@@ -228,26 +229,26 @@ class SourceShell:
             _LOGGER.error("Error rendering price template '%s': %s. Falling back to market price.", template_str, e)
             return market_price
 
-    def get_import_price(self, hass, market_price_per_kwh: float, dt_value=None) -> float:
+    def get_import_price(self, market_price_per_kwh: float, dt_value=None) -> float:
         """Calculate custom import price based on user template or fallback to standard calculation."""
         template_str = self._config_entry.options.get(CONF_TEMPLATE_IMPORT, "")
         
         # If user provided a custom template, use it
         if template_str and template_str.strip() != "":
             target_dt = dt_value if dt_value else dt.now()
-            return round(self._render_custom_template(hass, template_str, market_price_per_kwh, target_dt), 6)
+            return round(self._render_custom_template(template_str, market_price_per_kwh, target_dt), 6)
             
         # Fallback to the original built-in calculation if template is empty
         return self.to_total_price(market_price_per_kwh)
 
-    def get_export_price(self, hass, market_price_per_kwh: float, dt_value=None) -> float:
+    def get_export_price(self, market_price_per_kwh: float, dt_value=None) -> float:
         """Calculate custom export price based on user template or fallback to standard calculation."""
         template_str = self._config_entry.options.get(CONF_TEMPLATE_EXPORT, "")
         
         # If user provided a custom template, use it
         if template_str and template_str.strip() != "":
             target_dt = dt_value if dt_value else dt.now()
-            return round(self._render_custom_template(hass, template_str, market_price_per_kwh, target_dt), 6)
+            return round(self._render_custom_template(template_str, market_price_per_kwh, target_dt), 6)
             
         # Fallback to the original built-in calculation if template is empty
         return self.to_total_price(market_price_per_kwh)

--- a/custom_components/epex_spot/SourceShell.py
+++ b/custom_components/epex_spot/SourceShell.py
@@ -8,6 +8,7 @@ import aiohttp
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.util import dt
+from homeassistant.helpers import template as template_helper
 
 from custom_components.epex_spot.const import (
     CONF_DURATION,
@@ -27,6 +28,8 @@ from custom_components.epex_spot.const import (
     CONF_SOURCE_HOFER_GRUENSTROM,
     CONF_SURCHARGE_ABS,
     CONF_SURCHARGE_PERC,
+    CONF_TEMPLATE_IMPORT,
+    CONF_TEMPLATE_EXPORT,
     CONF_TAX,
     CONF_TOKEN,
     DEFAULT_DURATION,
@@ -202,6 +205,52 @@ class SourceShell:
             total_price *= 1 + (tax / 100.0)
 
         return round(total_price, 6)
+        
+    def _render_custom_template(self, hass, template_str: str, market_price: float, dt_value) -> float:
+        """Helper to render a custom Jinja2 template with price and datetime context."""
+        if not template_str or template_str.strip() == "":
+            return market_price
+
+        try:
+            # Create a Home Assistant Template object
+            compiled_template = template_helper.Template(template_str, hass)
+            
+            # Context variables available to the end-user
+            variables = {
+                "market_price": market_price,
+                "now": lambda: dt.as_local(dt_value),
+            }
+            
+            # Render and convert to float
+            rendered_value = compiled_template.async_render(variables, parse_result=True)
+            return float(rendered_value)
+        except Exception as e:
+            _LOGGER.error("Error rendering price template '%s': %s. Falling back to market price.", template_str, e)
+            return market_price
+
+    def get_import_price(self, hass, market_price_per_kwh: float, dt_value=None) -> float:
+        """Calculate custom import price based on user template or fallback to standard calculation."""
+        template_str = self._config_entry.options.get(CONF_TEMPLATE_IMPORT, "")
+        
+        # If user provided a custom template, use it
+        if template_str and template_str.strip() != "":
+            target_dt = dt_value if dt_value else dt.now()
+            return round(self._render_custom_template(hass, template_str, market_price_per_kwh, target_dt), 6)
+            
+        # Fallback to the original built-in calculation if template is empty
+        return self.to_total_price(market_price_per_kwh)
+
+    def get_export_price(self, hass, market_price_per_kwh: float, dt_value=None) -> float:
+        """Calculate custom export price based on user template or fallback to standard calculation."""
+        template_str = self._config_entry.options.get(CONF_TEMPLATE_EXPORT, "")
+        
+        # If user provided a custom template, use it
+        if template_str and template_str.strip() != "":
+            target_dt = dt_value if dt_value else dt.now()
+            return round(self._render_custom_template(hass, template_str, market_price_per_kwh, target_dt), 6)
+            
+        # Fallback to the original built-in calculation if template is empty
+        return self.to_total_price(market_price_per_kwh)
 
     def find_extreme_price_interval(self, call_data, cmp):
         duration: timedelta = call_data[CONF_DURATION]
@@ -227,5 +276,5 @@ class SourceShell:
             "start": result["start"],
             "end": result["start"] + duration,
             "market_price_per_kwh": round(result["market_price_per_hour"], 6),
-            "total_price_per_kwh": self.to_total_price(result["market_price_per_hour"]),
+            "total_price_per_kwh": self.get_import_price(result["market_price_per_hour"], result["start"]),
         }

--- a/custom_components/epex_spot/__init__.py
+++ b/custom_components/epex_spot/__init__.py
@@ -68,7 +68,7 @@ FETCH_DATA_SCHEMA = vol.Schema(
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up component from a config entry."""
 
-    source = SourceShell(entry, async_get_clientsession(hass))
+    source = SourceShell(hass, entry, async_get_clientsession(hass))
 
     try:
         await source.fetch()

--- a/custom_components/epex_spot/config_flow.py
+++ b/custom_components/epex_spot/config_flow.py
@@ -202,6 +202,9 @@ class EpexSpotOptionsFlow(OptionsFlowWithReload):
                 ),
                 self.config_entry.options
             ),
+            description_placeholders={
+                'docs_templates_url': "https://github.com/mampfes/ha_epex_spot/blob/main/docs/templates.md"
+            },
         )
 
 

--- a/custom_components/epex_spot/config_flow.py
+++ b/custom_components/epex_spot/config_flow.py
@@ -171,39 +171,36 @@ class EpexSpotOptionsFlow(OptionsFlowWithReload):
 
         return self.async_show_form(
             step_id="init",
-            data_schema=vol.Schema(
-                {
-                    vol.Optional(
-                        CONF_SURCHARGE_PERC,
-                        default=self.config_entry.options.get(
-                            CONF_SURCHARGE_PERC, DEFAULT_SURCHARGE_PERC
-                        ),
-                    ): vol.Coerce(float),
-                    vol.Optional(
-                        CONF_SURCHARGE_ABS,
-                        default=self.config_entry.options.get(
-                            CONF_SURCHARGE_ABS, DEFAULT_SURCHARGE_ABS
-                        ),
-                    ): vol.Coerce(float),
-                    vol.Optional(
-                        CONF_TAX,
-                        default=self.config_entry.options.get(CONF_TAX, DEFAULT_TAX),
-                    ): vol.Coerce(float),
-                    vol.Required(
-                        CONF_DURATION,
-                        default=self.config_entry.options.get(
-                            CONF_DURATION, DEFAULT_DURATION
-                        ),
-                    ): vol.In(durations),
-                    vol.Optional(
-                        CONF_TEMPLATE_IMPORT,
-                        default=self.config_entry.options.get(CONF_TEMPLATE_IMPORT, ""),
-                    ): TemplateSelector(),
-                    vol.Optional(
-                        CONF_TEMPLATE_EXPORT,
-                        default=self.config_entry.options.get(CONF_TEMPLATE_EXPORT, ""),
-                    ): TemplateSelector(),
-                }
+            data_schema=self.add_suggested_values_to_schema(
+                vol.Schema(
+                    {
+                        vol.Optional(
+                            CONF_SURCHARGE_PERC,
+                            default=self.config_entry.options.get(
+                                CONF_SURCHARGE_PERC, DEFAULT_SURCHARGE_PERC
+                            ),
+                        ): vol.Coerce(float),
+                        vol.Optional(
+                            CONF_SURCHARGE_ABS,
+                            default=self.config_entry.options.get(
+                                CONF_SURCHARGE_ABS, DEFAULT_SURCHARGE_ABS
+                            ),
+                        ): vol.Coerce(float),
+                        vol.Optional(
+                            CONF_TAX,
+                            default=self.config_entry.options.get(CONF_TAX, DEFAULT_TAX),
+                        ): vol.Coerce(float),
+                        vol.Required(
+                            CONF_DURATION,
+                            default=self.config_entry.options.get(
+                                CONF_DURATION, DEFAULT_DURATION
+                            ),
+                        ): vol.In(durations),
+                        vol.Optional(CONF_TEMPLATE_IMPORT): TemplateSelector(),
+                        vol.Optional(CONF_TEMPLATE_EXPORT): TemplateSelector(),
+                    }
+                ),
+                self.config_entry.options
             ),
         )
 

--- a/custom_components/epex_spot/config_flow.py
+++ b/custom_components/epex_spot/config_flow.py
@@ -8,6 +8,7 @@ from typing import List, Tuple
 
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlowWithReload
 from homeassistant.core import callback
+from homeassistant.helpers.selector import TemplateSelector
 
 from .const import (
     CONF_MARKET_AREA,
@@ -22,6 +23,8 @@ from .const import (
     CONF_SOURCE_HOFER_GRUENSTROM,
     CONF_SURCHARGE_ABS,
     CONF_SURCHARGE_PERC,
+    CONF_TEMPLATE_IMPORT,
+    CONF_TEMPLATE_EXPORT,
     CONF_TAX,
     CONF_TOKEN,
     CONF_DURATION,
@@ -192,6 +195,14 @@ class EpexSpotOptionsFlow(OptionsFlowWithReload):
                             CONF_DURATION, DEFAULT_DURATION
                         ),
                     ): vol.In(durations),
+                    vol.Optional(
+                        CONF_TEMPLATE_IMPORT,
+                        default=self.config_entry.options.get(CONF_TEMPLATE_IMPORT, ""),
+                    ): TemplateSelector(),
+                    vol.Optional(
+                        CONF_TEMPLATE_EXPORT,
+                        default=self.config_entry.options.get(CONF_TEMPLATE_EXPORT, ""),
+                    ): TemplateSelector(),
                 }
             ),
         )

--- a/custom_components/epex_spot/const.py
+++ b/custom_components/epex_spot/const.py
@@ -31,6 +31,8 @@ CONF_SOURCE_HOFER_GRUENSTROM = "Hofer Gruenstrom"
 # configuration options for total price calculation
 CONF_SURCHARGE_PERC = "percentage_surcharge"
 CONF_SURCHARGE_ABS = "absolute_surcharge"
+CONF_TEMPLATE_IMPORT = "import_template"
+CONF_TEMPLATE_EXPORT = "export_template"
 CONF_TAX = "tax"
 
 # service call

--- a/custom_components/epex_spot/sensor.py
+++ b/custom_components/epex_spot/sensor.py
@@ -147,7 +147,6 @@ class EpexSpotCustomImportPriceSensorEntity(EpexSpotEntity, SensorEntity):
     @property
     def native_value(self) -> StateType:
         return self._source.get_import_price(
-            self.hass,
             self._source.marketdata_now.market_price_per_kwh,
             self._source.marketdata_now.start_time
         )
@@ -159,7 +158,6 @@ class EpexSpotCustomImportPriceSensorEntity(EpexSpotEntity, SensorEntity):
                 ATTR_START_TIME: dt_util.as_local(e.start_time).isoformat(),
                 ATTR_END_TIME: dt_util.as_local(e.end_time).isoformat(),
                 self._localized.attr_name_per_kwh: self._source.get_import_price(
-                    self.hass,
                     e.market_price_per_kwh,
                     e.start_time
                 ),
@@ -188,7 +186,6 @@ class EpexSpotCustomExportPriceSensorEntity(EpexSpotEntity, SensorEntity):
     @property
     def native_value(self) -> StateType:
         return self._source.get_export_price(
-            self.hass,
             self._source.marketdata_now.market_price_per_kwh,
             self._source.marketdata_now.start_time
         )
@@ -200,7 +197,6 @@ class EpexSpotCustomExportPriceSensorEntity(EpexSpotEntity, SensorEntity):
                 ATTR_START_TIME: dt_util.as_local(e.start_time).isoformat(),
                 ATTR_END_TIME: dt_util.as_local(e.end_time).isoformat(),
                 self._localized.attr_name_per_kwh: self._source.get_export_price(
-                    self.hass,
                     e.market_price_per_kwh,
                     e.start_time
                 ),

--- a/custom_components/epex_spot/sensor.py
+++ b/custom_components/epex_spot/sensor.py
@@ -46,14 +46,14 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         EpexSpotMedianPriceSensorEntity(coordinator),
     ]
     
-    # Only add the Custom Import/Export Sensor if the template is not empty
+    # Only add the Import/Export Sensor if the template is not empty
     import_template = config_entry.options.get(CONF_TEMPLATE_IMPORT, "")
     if import_template and import_template.strip() != "":
-        entities.append(EpexSpotCustomImportPriceSensorEntity(coordinator))
+        entities.append(EpexSpotImportPriceSensorEntity(coordinator))
         
     export_template = config_entry.options.get(CONF_TEMPLATE_EXPORT, "")
     if export_template and export_template.strip() != "":
-        entities.append(EpexSpotCustomExportPriceSensorEntity(coordinator))
+        entities.append(EpexSpotExportPriceSensorEntity(coordinator))
 
     async_add_entities(entities)
 
@@ -129,12 +129,12 @@ class EpexSpotTotalPriceSensorEntity(EpexSpotEntity, SensorEntity):
 
         return {ATTR_DATA: data}
 
-class EpexSpotCustomImportPriceSensorEntity(EpexSpotEntity, SensorEntity):
-    """Home Assistant sensor containing custom template-based import price."""
+class EpexSpotImportPriceSensorEntity(EpexSpotEntity, SensorEntity):
+    """Home Assistant sensor containing template-based import price."""
 
     entity_description = SensorEntityDescription(
-        key="Custom Import Price",
-        name="Custom Import Price",
+        key="Import Price",
+        name="Import Price",
         suggested_display_precision=6,
         state_class=SensorStateClass.MEASUREMENT,
     )
@@ -168,12 +168,12 @@ class EpexSpotCustomImportPriceSensorEntity(EpexSpotEntity, SensorEntity):
         return {ATTR_DATA: data}
 
 
-class EpexSpotCustomExportPriceSensorEntity(EpexSpotEntity, SensorEntity):
-    """Home Assistant sensor containing custom template-based export price."""
+class EpexSpotExportPriceSensorEntity(EpexSpotEntity, SensorEntity):
+    """Home Assistant sensor containing template-based export price."""
 
     entity_description = SensorEntityDescription(
-        key="Custom Export Price",
-        name="Custom Export Price",
+        key="Export Price",
+        name="Export Price",
         suggested_display_precision=6,
         state_class=SensorStateClass.MEASUREMENT,
     )

--- a/custom_components/epex_spot/sensor.py
+++ b/custom_components/epex_spot/sensor.py
@@ -19,6 +19,8 @@ from .const import (
     ATTR_START_TIME,
     ATTR_VOLUME_MWH,
     CONF_SOURCE,
+    CONF_TEMPLATE_IMPORT,
+    CONF_TEMPLATE_EXPORT,
     DOMAIN,
 )
 from . import EpexSpotEntity, EpexSpotDataUpdateCoordinator as DataUpdateCoordinator
@@ -43,6 +45,15 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         EpexSpotAveragePriceSensorEntity(coordinator),
         EpexSpotMedianPriceSensorEntity(coordinator),
     ]
+    
+    # Only add the Custom Import/Export Sensor if the template is not empty
+    import_template = config_entry.options.get(CONF_TEMPLATE_IMPORT, "")
+    if import_template and import_template.strip() != "":
+        entities.append(EpexSpotCustomImportPriceSensorEntity(coordinator))
+        
+    export_template = config_entry.options.get(CONF_TEMPLATE_EXPORT, "")
+    if export_template and export_template.strip() != "":
+        entities.append(EpexSpotCustomExportPriceSensorEntity(coordinator))
 
     async_add_entities(entities)
 
@@ -118,6 +129,86 @@ class EpexSpotTotalPriceSensorEntity(EpexSpotEntity, SensorEntity):
 
         return {ATTR_DATA: data}
 
+class EpexSpotCustomImportPriceSensorEntity(EpexSpotEntity, SensorEntity):
+    """Home Assistant sensor containing custom template-based import price."""
+
+    entity_description = SensorEntityDescription(
+        key="Custom Import Price",
+        name="Custom Import Price",
+        suggested_display_precision=6,
+        state_class=SensorStateClass.MEASUREMENT,
+    )
+
+    def __init__(self, coordinator: DataUpdateCoordinator):
+        super().__init__(coordinator, self.entity_description)
+        self._attr_icon = self._localized.icon
+        self._attr_native_unit_of_measurement = self._localized.uom_per_kwh
+
+    @property
+    def native_value(self) -> StateType:
+        return self._source.get_import_price(
+            self.hass,
+            self._source.marketdata_now.market_price_per_kwh,
+            self._source.marketdata_now.start_time
+        )
+
+    @property
+    def extra_state_attributes(self):
+        data = [
+            {
+                ATTR_START_TIME: dt_util.as_local(e.start_time).isoformat(),
+                ATTR_END_TIME: dt_util.as_local(e.end_time).isoformat(),
+                self._localized.attr_name_per_kwh: self._source.get_import_price(
+                    self.hass,
+                    e.market_price_per_kwh,
+                    e.start_time
+                ),
+            }
+            for e in self._source.marketdata
+        ]
+
+        return {ATTR_DATA: data}
+
+
+class EpexSpotCustomExportPriceSensorEntity(EpexSpotEntity, SensorEntity):
+    """Home Assistant sensor containing custom template-based export price."""
+
+    entity_description = SensorEntityDescription(
+        key="Custom Export Price",
+        name="Custom Export Price",
+        suggested_display_precision=6,
+        state_class=SensorStateClass.MEASUREMENT,
+    )
+
+    def __init__(self, coordinator: DataUpdateCoordinator):
+        super().__init__(coordinator, self.entity_description)
+        self._attr_icon = self._localized.icon
+        self._attr_native_unit_of_measurement = self._localized.uom_per_kwh
+
+    @property
+    def native_value(self) -> StateType:
+        return self._source.get_export_price(
+            self.hass,
+            self._source.marketdata_now.market_price_per_kwh,
+            self._source.marketdata_now.start_time
+        )
+
+    @property
+    def extra_state_attributes(self):
+        data = [
+            {
+                ATTR_START_TIME: dt_util.as_local(e.start_time).isoformat(),
+                ATTR_END_TIME: dt_util.as_local(e.end_time).isoformat(),
+                self._localized.attr_name_per_kwh: self._source.get_export_price(
+                    self.hass,
+                    e.market_price_per_kwh,
+                    e.start_time
+                ),
+            }
+            for e in self._source.marketdata
+        ]
+
+        return {ATTR_DATA: data}
 
 class EpexSpotBuyVolumeSensorEntity(EpexSpotEntity, SensorEntity):
     """Home Assistant sensor containing all EPEX spot data."""

--- a/custom_components/epex_spot/translations/en.json
+++ b/custom_components/epex_spot/translations/en.json
@@ -25,8 +25,8 @@
           "percentage_surcharge": "Percentage Surcharge (%)",
           "absolute_surcharge": "Absolute Surcharge (€/£ per kWh)",
           "tax": "Tax (%)",
-          "import_template": "Custom import price template.",
-          "export_template": "Custom export price template."
+          "import_template": "Import price template.",
+          "export_template": "Export price template."
         },
         "data_description": {
           "tax": "Like Value Added Tax (VAT)"
@@ -44,8 +44,8 @@
           "percentage_surcharge": "Percentage Surcharge (%)",
           "absolute_surcharge": "Absolute Surcharge (€/£ per kWh)",
           "tax": "Tax (%)",
-          "import_template": "Custom import price template.",
-          "export_template": "Custom export price template."
+          "import_template": "Import price template.",
+          "export_template": "Export price template."
         },
         "data_description": {
           "tax": "Like Value Added Tax (VAT)"

--- a/custom_components/epex_spot/translations/en.json
+++ b/custom_components/epex_spot/translations/en.json
@@ -20,7 +20,7 @@
       },
       "options": {
         "title": "Total Price Options",
-        "description": "Configure surcharges and tax to calculate total price per kWh, our use custom price templates. Check out our [ready-to-use energy provider templates](https://github.com/mampfes/ha_epex_spot/blob/main/docs/templates.md)!",
+        "description": "Configure surcharges and tax to calculate total price per kWh, our use custom price templates. Check out our [ready-to-use energy provider templates]({docs_templates_url})!",
         "data": {
           "percentage_surcharge": "Percentage Surcharge (%)",
           "absolute_surcharge": "Absolute Surcharge (€/£ per kWh)",
@@ -38,7 +38,7 @@
     "step": {
       "init": {
         "title": "Total Price Options",
-        "description": "Configure surcharges and tax to calculate total price per kWh, our use custom price templates. Check out our [ready-to-use energy provider templates](https://github.com/mampfes/ha_epex_spot/blob/main/docs/templates.md)!",
+        "description": "Configure surcharges and tax to calculate total price per kWh, our use custom price templates. Check out our [ready-to-use energy provider templates]({docs_templates_url})!",
         "data": {
           "duration": "Slot duration",
           "percentage_surcharge": "Percentage Surcharge (%)",

--- a/custom_components/epex_spot/translations/en.json
+++ b/custom_components/epex_spot/translations/en.json
@@ -29,9 +29,7 @@
           "export_template": "Custom export price template."
         },
         "data_description": {
-          "tax": "Like Value Added Tax (VAT)",
-          "import_template": "E.g.: {{{ market_price + 0.05 }}}.",
-          "export_template": "E.g.: {{{ market_price * 0.9 }}}."
+          "tax": "Like Value Added Tax (VAT)"
         }
       }
     }
@@ -50,9 +48,7 @@
           "export_template": "Custom export price template."
         },
         "data_description": {
-          "tax": "Like Value Added Tax (VAT)",
-          "import_template": "E.g.: {{{ market_price + 0.05 }}}.",
-          "export_template": "E.g.: {{{ market_price * 0.9 }}}."
+          "tax": "Like Value Added Tax (VAT)"
         }
       }
     }

--- a/custom_components/epex_spot/translations/en.json
+++ b/custom_components/epex_spot/translations/en.json
@@ -20,16 +20,18 @@
       },
       "options": {
         "title": "Total Price Options",
-        "description": "Configure surcharges and tax to calculate total price per kWh.",
+        "description": "Configure surcharges and tax to calculate total price per kWh, our use custom price templates. Check out our [ready-to-use energy provider templates](https://github.com/mampfes/ha_epex_spot/blob/main/docs/templates.md)!",
         "data": {
           "percentage_surcharge": "Percentage Surcharge (%)",
           "absolute_surcharge": "Absolute Surcharge (€/£ per kWh)",
           "tax": "Tax (%)",
-          "import_template": "Custom import price template. (Overrides other total price calculations)",
+          "import_template": "Custom import price template.",
           "export_template": "Custom export price template."
         },
         "data_description": {
-          "tax": "Like Value Added Tax (VAT)"
+          "tax": "Like Value Added Tax (VAT)",
+          "import_template": "E.g.: {{{ market_price + 0.05 }}}.",
+          "export_template": "E.g.: {{{ market_price * 0.9 }}}."
         }
       }
     }
@@ -38,17 +40,19 @@
     "step": {
       "init": {
         "title": "Total Price Options",
-        "description": "Configure surcharges and tax to calculate total price per kWh.",
+        "description": "Configure surcharges and tax to calculate total price per kWh, our use custom price templates. Check out our [ready-to-use energy provider templates](https://github.com/mampfes/ha_epex_spot/blob/main/docs/templates.md)!",
         "data": {
           "duration": "Slot duration",
           "percentage_surcharge": "Percentage Surcharge (%)",
           "absolute_surcharge": "Absolute Surcharge (€/£ per kWh)",
           "tax": "Tax (%)",
-          "import_template": "Custom import price template. (Overrides other total price calculations)",
+          "import_template": "Custom import price template.",
           "export_template": "Custom export price template."
         },
         "data_description": {
-          "tax": "Like Value Added Tax (VAT)"
+          "tax": "Like Value Added Tax (VAT)",
+          "import_template": "E.g.: {{{ market_price + 0.05 }}}.",
+          "export_template": "E.g.: {{{ market_price * 0.9 }}}."
         }
       }
     }

--- a/custom_components/epex_spot/translations/en.json
+++ b/custom_components/epex_spot/translations/en.json
@@ -25,8 +25,8 @@
           "percentage_surcharge": "Percentage Surcharge (%)",
           "absolute_surcharge": "Absolute Surcharge (€/£ per kWh)",
           "tax": "Tax (%)",
-          "import_template": "Import price template.",
-          "export_template": "Export price template."
+          "import_template": "Import price template",
+          "export_template": "Export price template"
         },
         "data_description": {
           "tax": "Like Value Added Tax (VAT)"
@@ -44,8 +44,8 @@
           "percentage_surcharge": "Percentage Surcharge (%)",
           "absolute_surcharge": "Absolute Surcharge (€/£ per kWh)",
           "tax": "Tax (%)",
-          "import_template": "Import price template.",
-          "export_template": "Export price template."
+          "import_template": "Import price template",
+          "export_template": "Export price template"
         },
         "data_description": {
           "tax": "Like Value Added Tax (VAT)"

--- a/custom_components/epex_spot/translations/en.json
+++ b/custom_components/epex_spot/translations/en.json
@@ -24,7 +24,9 @@
         "data": {
           "percentage_surcharge": "Percentage Surcharge (%)",
           "absolute_surcharge": "Absolute Surcharge (€/£ per kWh)",
-          "tax": "Tax (%)"
+          "tax": "Tax (%)",
+          "import_template": "Custom import price template. (Overrides other total price calculations)",
+          "export_template": "Custom export price template."
         },
         "data_description": {
           "tax": "Like Value Added Tax (VAT)"
@@ -41,7 +43,9 @@
           "duration": "Slot duration",
           "percentage_surcharge": "Percentage Surcharge (%)",
           "absolute_surcharge": "Absolute Surcharge (€/£ per kWh)",
-          "tax": "Tax (%)"
+          "tax": "Tax (%)",
+          "import_template": "Custom import price template. (Overrides other total price calculations)",
+          "export_template": "Custom export price template."
         },
         "data_description": {
           "tax": "Like Value Added Tax (VAT)"

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,6 +1,26 @@
 # Ready-to-Use Energy Provider Price Templates
 
-Below is a list of pre-configured templates for popular dynamic energy providers. You can copy and paste these directly into the **Custom Import Template** and/or **Custom Export Template** field in the integration options.
+Below is a list of pre-configured templates for popular dynamic energy providers. You can copy and paste these directly into the **Import price template** and/or **Export price template** field in the integration options.
+
+---
+
+## 🛠️ Available Variables in Templates
+
+When writing or customizing your own templates, the integration exposes the following variables:
+
+* **`market_price`**: The raw EPEX spot market price per kWh as a floating-point number.
+* **`now()`**: A localized Home Assistant `datetime` object representing the specific hour/interval block being evaluated. 
+  * *Tip:* This allows you to check the current hour (`now().hour`), month (`now().month`), or day of the week (`now().weekday()`) to build time-of-day or seasonal pricing.
+
+---
+
+## 🌍 Quick Navigation
+
+Select your country to jump directly to the configuration templates:
+
+* [🇳🇱 Netherlands (Nederland)](#-netherlands-nederland)
+* [🇦🇹 Austria (Österreich)](#-austria-österreich)
+* [🇩🇪 Germany (Deutschland)](#-germany-deutschland)
 
 ---
 
@@ -80,6 +100,106 @@ Zonneplan applies a fixed surcharge per kWh including procurement costs for impo
 {% endif %}
 ```
   
+---
+
+## 🇦🇹 Austria (Österreich)
+
+### Sommer-Nieder-Arbeitspreis (SNAP)
+
+As of April 1, 2026, Austria introduced the **Sommer-Nieder-Arbeitspreis (SNAP)** for grid distribution fees (Netzebene 7 / households). This regulation grants a **20% discount on the grid usage rate** (Netznutzungsentgelt) during the summer half-year (**April 1st to September 30th**) between **10:00 and 16:00** daily.
+
+Below is a template that automatically applies the SNAP discount based on the current month and hour, and adds your fixed charges and VAT.
+
+```jinja2
+{# --- CONFIGURATION OF YOUR FIXED RATES (Adjust to your situation) --- #}
+{% set base_grid_rate = 0.0700 %} {# Your normal grid usage rate per kWh excluding VAT #}
+{% set other_surcharges = 0.1234 %} {# Energy taxes, fixed surcharges, etc. #}
+{% set vat = 1.20 %} {# 20% VAT in Austria #}
+
+{# --- SNAP LOGICA (Automatic Calculation) --- #}
+{% set is_summer_month = now().month >= 4 and now().month <= 9 %}
+{% set is_snap_hour = now().hour >= 10 and now().hour < 16 %}
+
+{% if is_summer_month and is_snap_hour %}
+  {# 20% discount on the grid rate during SNAP hours #}
+  {% set current_grid_rate = base_grid_rate * 0.80 %}
+{% else %}
+  {# Regular grid rate outside of SNAP hours #}
+  {% set current_grid_rate = base_grid_rate %}
+{% endif %}
+
+{# --- FINAL PRICE CALCULATION --- #}
+{{ (market_price + current_grid_rate + other_surcharges) * vat }}
+```
+
+---
+
+## 🇩🇪 Germany (Deutschland)
+
+### §14a EnWG (Import)
+
+Under **§14a EnWG**, German grid operators (Netzbetreiber) provide time-variable grid fees (HT, ST, NT). 
+
+**Quarterly variation:** Operators can restrict these variable time-windows to specific quarters of the year (e.g., only during high-load winter or high-solar summer quarters). During off-quarters, the Standard Tariff (ST) usually applies 24/7.
+
+>[!NOTE]
+>**Price Intervals & Time Restrictions**
+>
+>If your integration is configured to use a 1-hour price interval, you cannot apply grid fee changes that occur on half-hour or quarter-hour marks (e.g., a tariff switching at 17:30).
+>The rate determined at the start of the hour will be calculated for the entire hour. If your local grid operator enforces strict mid-hour tariff shifts, consider switching the integration to a 15-minute price interval sensor (if available for your region) to ensure accurate calculations.
+
+```jinja2
+{# --- CONFIGURATION OF YOUR LOCAL GRID FEES --- #}
+{% set grid_nt = 0.0250 %} {# Low tariff rate per kWh #}
+{% set grid_st = 0.0550 %} {# Standard tariff rate per kWh #}
+{% set grid_ht = 0.0850 %} {# High tariff rate per kWh #}
+
+{% set other_surcharges = 0.1420 %} {# Taxes, StromSt, etc. #}
+{% set vat = 1.19 %} {# 19% VAT #}
+
+{# --- QUARTERLY & TIME PROFILE LOGIC --- #}
+{% set current_month = now().month %}
+{% set current_hour = now().hour %}
+{% set is_weekend = now().weekday() >= 5 %}
+
+{# Define active quarters (Example: Q1/Jan-Mar and Q4/Oct-Dec are active) #}
+{% set is_active_quarter = current_month <= 3 or current_month >= 10 %}
+
+{% if is_active_quarter and not is_weekend %}
+  {# Weekday profile during active quarters (Peak morning/evening = HT, Night = NT) #}
+  {% if (current_hour >= 8 and current_hour < 12) or (current_hour >= 17 and current_hour < 19) %}
+    {% set current_grid_rate = grid_ht %}
+  {% elif (current_hour < 3) or (current_hour >= 19) %}
+    {% set current_grid_rate = grid_nt %}
+  {% else %}
+    {% set current_grid_rate = grid_st %}
+  {% endif %}
+{% else %}
+  {# Off-quarters or weekends: Variable fees are disabled, ST applies 24/7 #}
+  {# (Note: check if your provider uses NT on weekends during off-quarters) #}
+  {% set current_grid_rate = grid_st %}
+{% endif %}
+
+{# --- FINAL PRICE CALCULATION --- #}
+{{ (market_price + current_grid_rate + other_surcharges) * vat }}
+```
+
+
+### EEG-Feed-in with §51 EEG / Solarspitzengesetz (Export)
+
+For German PV owners utilizing the fixed statutory feed-in tariff (**EEG-Einspeisevergütung**), the rules regarding negative electricity prices became significantly stricter under the **Solarspitzengesetz**. 
+For new systems, your statutory feed-in compensation instantly drops to **€0.00** as soon as the EPEX SPOT market price falls below zero. Old systems retain their historical protection rules (*Bestandsschutz*).
+
+```jinja2
+{% if market_price <= 0 %}
+  {# If the EPEX market price drops below or equals 0, the statutory subsidy is voided #}
+  0.0000
+{% else %}
+  {# As long as the market price is positive, you receive your fixed tariff #}
+  0.0750
+{% endif %}
+```
+
 ---
 
 ## 🌍 Other Countries

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,0 +1,86 @@
+# Ready-to-Use Energy Provider Price Templates
+
+Below is a list of pre-configured templates for popular dynamic energy providers. You can copy and paste these directly into the **Custom Import Template** and/or **Custom Export Template** field in the integration options.
+
+---
+
+## 🇳🇱 Netherlands (Nederland)
+
+### 1. Zonneplan
+Zonneplan applies a fixed surcharge per kWh including procurement costs. For export (feeding back to the grid), they offer a **Zonnebonus** (10% extra yield on top of the total price including tax, between sunrise and sunset).
+* **Import Template:**
+```jinja2
+{# Energy tax #}
+{% if now().strftime('%Y-%m-%d') >= '2027-01-01' %}
+  {# Replace 0.1234 with the actual government energy tax rate for 2027, including VAT #}
+  {% set energy_tax = 0.1234 %}
+{% else %}
+  {# Current 2026 energy tax #}
+  {% set energy_tax = 0.110848 %}
+{% endif %}
+
+{{ (market_price * 1.21) + 0.02 + energy_tax }}
+```
+
+* **Export Template:**
+```jinja2
+{# Energy tax #}
+{% if now().strftime('%Y-%m-%d') >= '2027-01-01' %}
+  {# Energy tax return stops from January 1st, 2027 onwards #}
+  {% set energy_tax = 0 %}
+{% else %}
+  {# Current 2026 energy tax #}
+  {% set energy_tax = 0.110848 %}
+{% endif %}
+
+{% set export_base = (market_price * 1.21) + 0.02 %}
+{# Check if the calculated hour falls between sunrise and sunset #}
+{% if export_base > 0 and
+      now() > today_at(state_attr('sun.sun', 'next_rising') | as_timestamp | timestamp_custom('%H:%M', true)) and 
+      now() < today_at(state_attr('sun.sun', 'next_setting') | as_timestamp | timestamp_custom('%H:%M', true)) %}
+  {{ (export_base * 1.10) + energy_tax }}
+{% else %}
+  {{ export_base + energy_tax }}
+{% endif %}
+```
+  
+### 2. NextEnergie
+Zonneplan applies a fixed surcharge per kWh including procurement costs for import only. For export NextEnergie offers a massive **Zonnebonus** (50% extra yield on top of your export price including tax, between 06:00 and 22:00).
+* **Import Template:**
+```jinja2
+{# Energy tax #}
+{% if now().strftime('%Y-%m-%d') >= '2027-01-01' %}
+  {# Replace 0.1234 with the actual government energy tax rate for 2027, including VAT #}
+  {% set energy_tax = 0.1234 %}
+{% else %}
+  {# Current 2026 energy tax #}
+  {% set energy_tax = 0.110848 %}
+{% endif %}
+
+{{ (market_price * 1.21) + 0.0219 + energy_tax }}
+```
+
+* **Export Template:**
+```jinja2
+{# Energy tax #}
+{% if now().strftime('%Y-%m-%d') >= '2027-01-01' %}
+  {# Energy tax return stops from January 1st, 2027 onwards #}
+  {% set energy_tax = 0 %}
+{% else %}
+  {# Current 2026 energy tax #}
+  {% set energy_tax = 0.110848 %}
+{% endif %}
+
+{% set export_base = market_price * 1.21 %}
+{# Check if the calculated hour is between 06:00 and 22:00 #}
+{% if export_base > 0 and now().hour >= 6 and now().hour < 22 %}
+  {{ export_base * 1.50 }}
+{% else %}
+  {{ export_base }}
+{% endif %}
+```
+  
+---
+
+## 🌍 Other Countries
+*Templates for other countries will be added here. Feel free to open a Pull Request to submit yours!*

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -74,9 +74,9 @@ Zonneplan applies a fixed surcharge per kWh including procurement costs for impo
 {% set export_base = market_price * 1.21 %}
 {# Check if the calculated hour is between 06:00 and 22:00 #}
 {% if export_base > 0 and now().hour >= 6 and now().hour < 22 %}
-  {{ export_base * 1.50 }}
+  {{ (export_base * 1.50) + energy_tax }}
 {% else %}
-  {{ export_base }}
+  {{ export_base + energy_tax }}
 {% endif %}
 ```
   


### PR DESCRIPTION
## Description
This PR introduces advanced customization options for dynamic energy contracts by allowing users to define custom Jinja2 templates for **Import** and **Export** prices directly within the integration's Options flow. 

When configured, two new dynamic entities (`Import Price` and `Export Price`) are created. These templates have access to `market_price` and a localized `now()` object that matches the specific hour block being evaluated, ensuring highly accurate future pricing forecasts (e.g., for ApexCharts or the Energy Dashboard).

Leaving these template fields blank keeps the sensors inactive, maintaining 100% backward compatibility for existing users.

## Changes
* **`const.py`**: Added configuration keys `CONF_TEMPLATE_IMPORT` and `CONF_TEMPLATE_EXPORT` to maintain uniform keys across the integration.
* **`config_flow.py`**: Added optional `import_template` and `export_template` fields using Home Assistant's `TemplateSelector` for a rich multiline code editor experience.
* **`translations/en.json`**: Added English localized descriptions for the new configuration options.
* **`SourceShell.py`**: Implemented `get_import_price` and `get_export_price` with safe Jinja2 rendering logic. Overrode the `now` variable context with the localized timestamp of each specific hour block.
* **`sensor.py`**: Added conditional setup logic to dynamically spawn the new custom sensor entities only when templates are explicitly provided.
* **`README.md`**: Updated the documentation.

## Testing
* Verified that leaving templates blank does not spawn the sensors and doesn't affect standard functionality.
* Verified that saving a template automatically triggers a config entry reload and creates the sensors.
* Tested time-of-day logic and date conditions inside the Jinja2 editor; verified that future attributes align perfectly with the correct local time blocks.