### PR TITLE
Add EnergyZero

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ You can choose between multiple sources:
 
    ⚠️ **Note:** The SSL certificate used by the Hofer Grünstrom API is not trusted publicly. Therefore, when using this source, the integration will ignore SSL certificate verification. This is a potential security risk, so please be aware of this when using this source.
 
+9. EnergyZero
+   [EnergyZero](https://external.docs.api.staging.energyzero.nl/docs/api/rest/public/energy-market-service-get-prices) provides a public API that offers EPEX Spot market prices for the Netherlands. EnergyZero acts as the back-end platform and price provider for various dynamic energy labels, including **ANWB Energie**, **Greenchoice**, **Energie van Ons**, **Mijndomein Energie**, and **Vrijopnaam**. No registration or API token is required.
+   
 If you like this component, please give it a star on [github](https://github.com/mampfes/hacs_epex_spot).
 
 ## Installation

--- a/custom_components/epex_spot/EPEXSpot/EnergyZero/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/EnergyZero/__init__.py
@@ -1,0 +1,84 @@
+"""EnergyZero API."""
+
+from datetime import datetime
+import aiohttp
+import logging
+
+from ...common import Marketprice
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class EnergyZero:
+    URL = "https://public.api.energyzero.nl/public/v1/prices"
+
+    MARKET_AREAS = ("nl",)
+    SUPPORTED_DURATIONS = (15, 60)
+
+    def __init__(
+        self,
+        market_area: str,
+        duration: int,
+        session: aiohttp.ClientSession,
+    ):
+        self._session = session
+        self._market_area = market_area
+        self._duration = duration
+        self._marketdata = []
+
+    @property
+    def name(self):
+        return f"EnergyZero ({'Quarterly' if self._duration == 15 else 'Hourly'})"
+
+    @property
+    def market_area(self):
+        return self._market_area
+
+    @property
+    def duration(self):
+        return self._duration
+
+    @property
+    def currency(self):
+        return "EUR"
+
+    @property
+    def marketdata(self):
+        return self._marketdata
+
+    async def fetch(self):
+        """Fetch market price data using EnergyZero's rolling data window."""
+        self._marketdata = []
+        now = datetime.now()
+
+        date_str = now.strftime("%d-%m-%Y")
+        interval = "INTERVAL_QUARTER" if self._duration == 15 else "INTERVAL_HOUR"
+
+        params = {
+            "date": date_str,
+            "interval": interval,
+            "energyType": "ENERGY_TYPE_ELECTRICITY"
+        }
+
+        try:
+            async with self._session.get(self.URL, params=params) as resp:
+                resp.raise_for_status()
+                data = await resp.json()
+                
+                if "base" in data:
+                    for entry in data["base"]:
+                        start_time = datetime.fromisoformat(entry["start"])
+                        price = float(entry["price"]["value"])
+                        
+                        self._marketdata.append(
+                            Marketprice(
+                                duration=self._duration,
+                                start_time=start_time,
+                                price=round(price, 6)
+                            )
+                        )
+        except Exception as e:
+            _LOGGER.error(f"Error fetching EnergyZero data for date {date_str}: {e}")
+
+        # Ensure all received data points are sorted chronologically
+        self._marketdata.sort(key=lambda x: x.start_time)

--- a/custom_components/epex_spot/EPEXSpot/EnergyZero/__init__.py
+++ b/custom_components/epex_spot/EPEXSpot/EnergyZero/__init__.py
@@ -48,7 +48,6 @@ class EnergyZero:
 
     async def fetch(self):
         """Fetch market price data using EnergyZero's rolling data window."""
-        self._marketdata = []
         now = datetime.now()
 
         date_str = now.strftime("%d-%m-%Y")
@@ -61,24 +60,32 @@ class EnergyZero:
         }
 
         try:
+            marketdata: list[Marketprice] = []
             async with self._session.get(self.URL, params=params) as resp:
                 resp.raise_for_status()
                 data = await resp.json()
-                
+
                 if "base" in data:
                     for entry in data["base"]:
                         start_time = datetime.fromisoformat(entry["start"])
                         price = float(entry["price"]["value"])
-                        
-                        self._marketdata.append(
+
+                        marketdata.append(
                             Marketprice(
                                 duration=self._duration,
                                 start_time=start_time,
                                 price=round(price, 6)
                             )
                         )
+
+            minimal_points = int(23 * 60 / self._duration)
+            if len(marketdata) < minimal_points:
+                raise ValueError(
+                    f"Received incomplete data from EnergyZero. Expected at least {minimal_points} points, got {len(marketdata)}."
+                )
+
+            marketdata.sort(key=lambda x: x.start_time)
+            self._marketdata = marketdata
+
         except Exception as e:
             _LOGGER.error(f"Error fetching EnergyZero data for date {date_str}: {e}")
-
-        # Ensure all received data points are sorted chronologically
-        self._marketdata.sort(key=lambda x: x.start_time)

--- a/custom_components/epex_spot/SourceShell.py
+++ b/custom_components/epex_spot/SourceShell.py
@@ -25,6 +25,7 @@ from custom_components.epex_spot.const import (
     CONF_SOURCE_SMARTENERGY,
     CONF_SOURCE_TIBBER,
     CONF_SOURCE_HOFER_GRUENSTROM,
+    CONF_SOURCE_ENERGYZERO,
     CONF_SURCHARGE_ABS,
     CONF_SURCHARGE_PERC,
     CONF_TAX,
@@ -44,6 +45,7 @@ from custom_components.epex_spot.EPEXSpot import (
     ENTSOE,
     EnergyCharts,
     HoferGruenstrom,
+    EnergyZero,
 )
 from .extreme_price_interval import find_extreme_price_interval, get_start_times
 
@@ -106,6 +108,12 @@ class SourceShell:
             )
         elif config_entry.data[CONF_SOURCE] == CONF_SOURCE_HOFER_GRUENSTROM:
             self._source = HoferGruenstrom.HoferGruenstrom(
+                market_area=config_entry.data[CONF_MARKET_AREA],
+                duration=config_entry.options.get(CONF_DURATION, DEFAULT_DURATION),
+                session=session,
+            )
+        elif config_entry.data[CONF_SOURCE] == CONF_SOURCE_ENERGYZERO:
+            self._source = EnergyZero.EnergyZero(
                 market_area=config_entry.data[CONF_MARKET_AREA],
                 duration=config_entry.options.get(CONF_DURATION, DEFAULT_DURATION),
                 session=session,

--- a/custom_components/epex_spot/config_flow.py
+++ b/custom_components/epex_spot/config_flow.py
@@ -20,6 +20,7 @@ from .const import (
     CONF_SOURCE_ENERGYFORECAST,
     CONF_SOURCE_ENERGYCHARTS,
     CONF_SOURCE_HOFER_GRUENSTROM,
+    CONF_SOURCE_ENERGYZERO,
     CONF_SURCHARGE_ABS,
     CONF_SURCHARGE_PERC,
     CONF_TAX,
@@ -41,6 +42,7 @@ from .EPEXSpot import (
     ENTSOE,
     EnergyCharts,
     HoferGruenstrom,
+    EnergyZero,
 )
 
 CONF_SOURCE_LIST = (
@@ -52,6 +54,7 @@ CONF_SOURCE_LIST = (
     CONF_SOURCE_ENERGYFORECAST,
     CONF_SOURCE_ENERGYCHARTS,
     CONF_SOURCE_HOFER_GRUENSTROM,
+    CONF_SOURCE_ENERGYZERO,
 )
 
 
@@ -252,5 +255,10 @@ def getParametersForSource(
             HoferGruenstrom.HoferGruenstrom.SUPPORTED_DURATIONS,
             False,
         )
-
+    if source_name == CONF_SOURCE_ENERGYZERO:
+        return (
+            EnergyZero.EnergyZero.MARKET_AREAS,
+            EnergyZero.EnergyZero.SUPPORTED_DURATIONS,
+            False,
+        )
     return ([], [], False)

--- a/custom_components/epex_spot/const.py
+++ b/custom_components/epex_spot/const.py
@@ -27,6 +27,7 @@ CONF_SOURCE_ENERGYFORECAST = "Energyforecast.de"
 CONF_SOURCE_ENTSOE = "ENTSO-E-Transparency"
 CONF_SOURCE_ENERGYCHARTS = "Energy-Charts.info"
 CONF_SOURCE_HOFER_GRUENSTROM = "Hofer Gruenstrom"
+CONF_SOURCE_ENERGYZERO = "EnergyZero"
 
 # configuration options for total price calculation
 CONF_SURCHARGE_PERC = "percentage_surcharge"

--- a/custom_components/epex_spot/test_energyzero.py
+++ b/custom_components/epex_spot/test_energyzero.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import aiohttp
+import asyncio
+
+from .EPEXSpot import EnergyZero
+from .const import UOM_EUR_PER_KWH
+
+
+async def main():
+    async with aiohttp.ClientSession() as session:
+        durations = [15, 60]
+        for duration in durations:
+            service = EnergyZero.EnergyZero(
+                market_area="nl",
+                session=session,
+                duration=duration,
+            )
+            print(service.MARKET_AREAS)
+
+            await service.fetch()
+            print(f"duration={duration} count = {len(service.marketdata)}")
+            for e in service.marketdata:
+                print(f"{e.start_time}: {e.market_price_per_kwh} {UOM_EUR_PER_KWH}")
+
+
+asyncio.run(main())


### PR DESCRIPTION
## Description
This PR adds support for **EnergyZero** as a new data source for the Netherlands (`nl` market area). 

EnergyZero is a major back-end platform and price provider hosting various dynamic energy labels in the Netherlands, such as *ANWB Energie*, *Greenchoice*, *Energie van Ons*, *Mijndomein Energie*, and *Vrijopnaam*. 

### Key Features
* Supports both **Hourly** (`INTERVAL_HOUR`) and **Quarterly** (`INTERVAL_QUARTER`) price profiles.
* Fully public API: Completely free to use and **requires no authentication tokens** or registration.
* Utilizes EnergyZero's rolling data window feature to fetch available price points efficiently in a single request.


## How Has This Been Tested?
- [x] Tested locally using a standalone async test script (`test_energyzero.py`) validating correct chronological parsing for both 15-minute and 60-minute durations.
- [x] Verified response structure formatting matches internal integration helper expectations (`Marketprice`).

## Documentation Updates
* Updated `README.md` to list EnergyZero under supported market sources.